### PR TITLE
fix(sync): halt cursor on unexpected ON CONFLICT drops (#55)

### DIFF
--- a/scripts/audit-postgres-sync.py
+++ b/scripts/audit-postgres-sync.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""
+Audit PostgreSQL sync parity against the canonical JSONL/archive sources.
+
+Read-only reconciliation tool for detecting the silent row-loss failure
+mode described in issue #55. Compares the set of memory ids in
+``data/memories/memories.jsonl`` (canonical) against
+``claude_memories.memories`` (derived query layer), and optionally the
+set of session ids in ``~/cc-archives/*/session.meta.json`` against
+``claude_memories.sessions``.
+
+Designed as the detection half of the #55 fix — run before and after
+deploying the behavioural fix to confirm that (a) we can reproduce the
+bug's fingerprint (rows only in JSONL, not in PG) and (b) the fix
+eliminates it on new syncs.
+
+Exit codes:
+  0 — No rows are missing from PostgreSQL
+  1 — At least one canonical id is missing from PostgreSQL (the bug)
+  2 — Audit could not run (e.g., DB unavailable, JSONL missing)
+
+Usage:
+    venv/bin/python3 scripts/audit-postgres-sync.py
+    venv/bin/python3 scripts/audit-postgres-sync.py --sessions
+    venv/bin/python3 scripts/audit-postgres-sync.py --archive-root /path
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+# ============================================================================
+# Configuration — mirror the existing sync scripts so we use the same DB and
+# canonical locations. Do not invent new env-var names.
+# ============================================================================
+
+PA_DIR = Path(__file__).resolve().parent.parent
+MEMORIES_FILE = PA_DIR / "memories" / "memories.jsonl"
+DEFAULT_ARCHIVE_ROOT = Path.home() / "cc-archives"
+DB_NAME = "claude_memories"
+
+
+# ============================================================================
+# Logging
+# ============================================================================
+
+def setup_logging() -> logging.Logger:
+    """Configure a simple stderr logger for the audit run."""
+    logger = logging.getLogger("audit-postgres-sync")
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(
+        logging.Formatter("%(levelname)s: %(message)s")
+    )
+    logger.addHandler(handler)
+    return logger
+
+
+# ============================================================================
+# Result container
+# ============================================================================
+
+@dataclass
+class AuditResult:
+    """Summary of a reconciliation between canonical and PostgreSQL."""
+
+    source_name: str
+    canonical_count: int
+    postgres_count: int
+    only_in_canonical: list[str]
+    only_in_postgres: list[str]
+
+    @property
+    def is_clean(self) -> bool:
+        """True when no canonical ids are missing from PostgreSQL."""
+        return len(self.only_in_canonical) == 0
+
+
+# ============================================================================
+# Memory audit
+# ============================================================================
+
+def _read_jsonl_ids(jsonl_path: Path, logger: logging.Logger) -> set[str]:
+    """
+    Collect the set of ids in a JSONL canonical file.
+
+    Duplicates are tolerated — the latest occurrence wins by virtue of
+    set semantics (all occurrences map to the same id). Malformed lines
+    and records without an ``id`` are warned about but do not halt the
+    audit.
+    """
+    ids: set[str] = set()
+    with jsonl_path.open(encoding="utf-8") as f:
+        for line_number, line in enumerate(f, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                record = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "Malformed JSON at line %d: %s", line_number, exc
+                )
+                continue
+            mid = record.get("id")
+            if not mid:
+                logger.warning(
+                    "Missing id at line %d (skipped)", line_number
+                )
+                continue
+            ids.add(str(mid))
+    return ids
+
+
+def _read_postgres_ids(
+    table: str,
+    logger: logging.Logger,
+) -> Optional[set[str]]:
+    """
+    Return the set of ids from a PostgreSQL table, or ``None`` on error.
+
+    Uses the same connection conventions as the sync scripts
+    (``postgresql:///claude_memories`` via peer auth).
+    """
+    try:
+        import psycopg2
+    except ImportError:
+        logger.error(
+            "psycopg2 not installed. Run: venv/bin/pip install psycopg2-binary"
+        )
+        return None
+
+    try:
+        conn = psycopg2.connect(dbname=DB_NAME)
+    except psycopg2.OperationalError as exc:
+        logger.error("Cannot connect to PostgreSQL: %s", exc)
+        return None
+
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT id FROM {table}")
+                rows = cur.fetchall()
+        return {str(r[0]) for r in rows}
+    except Exception as exc:
+        logger.error("Query against %s failed: %s", table, exc)
+        return None
+    finally:
+        conn.close()
+
+
+def audit_memories(
+    jsonl_path: Path,
+    logger: logging.Logger,
+) -> Optional[AuditResult]:
+    """Reconcile memory ids between the JSONL canonical and PostgreSQL."""
+    if not jsonl_path.exists():
+        logger.error("Canonical JSONL not found: %s", jsonl_path)
+        return None
+
+    canonical_ids = _read_jsonl_ids(jsonl_path, logger)
+    postgres_ids = _read_postgres_ids("memories", logger)
+    if postgres_ids is None:
+        return None
+
+    only_canonical = sorted(canonical_ids - postgres_ids)
+    only_postgres = sorted(postgres_ids - canonical_ids)
+
+    return AuditResult(
+        source_name="memories",
+        canonical_count=len(canonical_ids),
+        postgres_count=len(postgres_ids),
+        only_in_canonical=only_canonical,
+        only_in_postgres=only_postgres,
+    )
+
+
+# ============================================================================
+# Session audit (optional)
+# ============================================================================
+
+def _read_session_archive_ids(
+    archive_root: Path,
+    logger: logging.Logger,
+) -> set[str]:
+    """Collect session ids from ``session.meta.json`` files under a root."""
+    ids: set[str] = set()
+    if not archive_root.exists():
+        logger.warning("Archive root does not exist: %s", archive_root)
+        return ids
+
+    for meta_path in archive_root.rglob("session.meta.json"):
+        try:
+            metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to parse %s: %s", meta_path, exc)
+            continue
+        sid = (metadata.get("session") or {}).get("id")
+        if sid:
+            ids.add(str(sid))
+    return ids
+
+
+def audit_sessions(
+    archive_root: Path,
+    logger: logging.Logger,
+) -> Optional[AuditResult]:
+    """Reconcile session ids between archive metadata and PostgreSQL."""
+    canonical_ids = _read_session_archive_ids(archive_root, logger)
+    postgres_ids = _read_postgres_ids("sessions", logger)
+    if postgres_ids is None:
+        return None
+
+    only_canonical = sorted(canonical_ids - postgres_ids)
+    only_postgres = sorted(postgres_ids - canonical_ids)
+
+    return AuditResult(
+        source_name="sessions",
+        canonical_count=len(canonical_ids),
+        postgres_count=len(postgres_ids),
+        only_in_canonical=only_canonical,
+        only_in_postgres=only_postgres,
+    )
+
+
+# ============================================================================
+# Reporting
+# ============================================================================
+
+def print_report(result: AuditResult) -> None:
+    """Print a human-readable summary of an audit result to stdout."""
+    print(f"=== {result.source_name} audit ===")
+    print(f"  canonical count : {result.canonical_count:>8}")
+    print(f"  postgres count  : {result.postgres_count:>8}")
+    print(f"  only in canonical: {len(result.only_in_canonical):>7}")
+    print(f"  only in postgres : {len(result.only_in_postgres):>7}")
+
+    if result.only_in_canonical:
+        print()
+        print(
+            "  The following ids are missing from PostgreSQL "
+            "(the #55 bug's fingerprint):"
+        )
+        for mid in result.only_in_canonical[:20]:
+            print(f"    - {mid}")
+        if len(result.only_in_canonical) > 20:
+            remaining = len(result.only_in_canonical) - 20
+            print(f"    ... and {remaining} more")
+
+    if result.only_in_postgres:
+        print()
+        print(
+            "  The following ids exist only in PostgreSQL "
+            "(likely orphans from deletions):"
+        )
+        for mid in result.only_in_postgres[:5]:
+            print(f"    - {mid}")
+        if len(result.only_in_postgres) > 5:
+            remaining = len(result.only_in_postgres) - 5
+            print(f"    ... and {remaining} more")
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+def main() -> int:
+    """Entry point. Returns the intended exit code."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit PostgreSQL parity against the canonical JSONL / "
+            "archive metadata (read-only)."
+        ),
+    )
+    parser.add_argument(
+        "--memories-file",
+        type=Path,
+        default=MEMORIES_FILE,
+        help=(
+            "Path to the canonical memories JSONL "
+            "(default: data/memories/memories.jsonl)."
+        ),
+    )
+    parser.add_argument(
+        "--sessions",
+        action="store_true",
+        help="Also audit the sessions table against ~/cc-archives/.",
+    )
+    parser.add_argument(
+        "--archive-root",
+        type=Path,
+        default=DEFAULT_ARCHIVE_ROOT,
+        help="Archive root for --sessions (default: ~/cc-archives).",
+    )
+    args = parser.parse_args()
+
+    logger = setup_logging()
+
+    results: list[AuditResult] = []
+
+    mem_result = audit_memories(args.memories_file, logger)
+    if mem_result is None:
+        return 2
+    results.append(mem_result)
+    print_report(mem_result)
+
+    if args.sessions:
+        print()
+        sess_result = audit_sessions(args.archive_root, logger)
+        if sess_result is None:
+            return 2
+        results.append(sess_result)
+        print_report(sess_result)
+
+    # Exit 1 if any audit found canonical rows missing from PostgreSQL.
+    if any(not r.is_clean for r in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync-sessions-to-postgres.py
+++ b/scripts/sync-sessions-to-postgres.py
@@ -21,9 +21,10 @@ import argparse
 import json
 import logging
 import sys
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import Any, Iterator, NamedTuple, Optional
 
 # ============================================================================
 # Configuration
@@ -41,6 +42,11 @@ QUARANTINE_FILE = PA_DIR / "data" / "sessions" / "quarantine-postgres-drops.json
 DB_NAME = "claude_memories"
 
 CURSOR_KEY = "sessions_sync_timestamp"
+
+# Advisory-lock key for serialising concurrent sessions-sync runs.
+# Distinct from the memories sync so the two scripts can run in parallel
+# against the same database without contending.
+ADVISORY_LOCK_KEY = "sync-sessions-to-postgres"
 
 
 # ============================================================================
@@ -238,7 +244,8 @@ class InsertResult(NamedTuple):
     Accounting result for a session upsert batch.
 
     Attributes:
-        input_count: Number of rows the caller handed us.
+        input_count: Number of rows attempted after within-batch dedup
+            (see ``duplicates_within_batch``).
         inserted: Number of rows returned by the upsert (should equal
             input_count under DO UPDATE — any shortfall is anomalous).
         expected_dupes: Always 0 for DO UPDATE — kept for shape parity
@@ -248,6 +255,8 @@ class InsertResult(NamedTuple):
             RETURNING. Under DO UPDATE these should never exist;
             anything here is a hard stop (#55).
         db_available: False when we could not reach the database.
+        duplicates_within_batch: Input rows that shared an id with
+            another row in the same batch; the last occurrence won.
     """
 
     input_count: int
@@ -255,6 +264,76 @@ class InsertResult(NamedTuple):
     expected_dupes: int
     unexpected_drops: list[str]
     db_available: bool
+    duplicates_within_batch: int = 0
+
+
+@contextmanager
+def _sync_advisory_lock(logger: logging.Logger) -> Iterator[bool]:
+    """
+    Acquire a PostgreSQL session-scoped advisory lock for the sync cycle.
+
+    Yields True when the sync should proceed, False when another sync
+    already holds the lock. The lock auto-releases when the backing
+    connection closes. If psycopg2 is missing or the database is
+    unreachable, yields True unconditionally — the upsert path handles
+    those cases and leaves the cursor alone (#55).
+    """
+    try:
+        import psycopg2
+    except ImportError:
+        yield True
+        return
+
+    try:
+        conn = psycopg2.connect(dbname=DB_NAME)
+    except psycopg2.OperationalError:
+        yield True
+        return
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_try_advisory_lock(hashtext(%s))",
+                (ADVISORY_LOCK_KEY,),
+            )
+            acquired = bool(cur.fetchone()[0])
+        conn.commit()
+        if not acquired:
+            logger.warning(
+                "Another sessions-sync holds the advisory lock for %r — "
+                "skipping this cycle. Will retry on next invocation.",
+                ADVISORY_LOCK_KEY,
+            )
+            yield False
+            return
+        yield True
+    finally:
+        conn.close()
+
+
+def _load_quarantined_ids() -> set[str]:
+    """
+    Return the set of ids already present in the quarantine JSONL.
+
+    Used to avoid appending duplicate rows on repeated sync runs
+    against a halted cursor.
+    """
+    if not QUARANTINE_FILE.exists():
+        return set()
+    ids: set[str] = set()
+    with QUARANTINE_FILE.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+                sid = rec.get("id")
+                if isinstance(sid, str):
+                    ids.add(sid)
+            except json.JSONDecodeError:
+                continue
+    return ids
 
 
 def _write_quarantine(
@@ -264,18 +343,36 @@ def _write_quarantine(
     """
     Append dropped session rows to the quarantine JSONL.
 
-    Creates parent directories and the file if missing.
+    Creates parent directories and the file if missing. Deduplicates
+    against already-quarantined ids so repeated runs against a halted
+    cursor do not grow the file linearly.
     """
+    already = _load_quarantined_ids()
+    new_rows = [r for r in dropped_rows if r.get("id") not in already]
+    if not new_rows:
+        logger.info(
+            "All %d dropped session row(s) already in quarantine — "
+            "no new appends",
+            len(dropped_rows),
+        )
+        return
+    skipped = len(dropped_rows) - len(new_rows)
     try:
         QUARANTINE_FILE.parent.mkdir(parents=True, exist_ok=True)
         with QUARANTINE_FILE.open("a", encoding="utf-8") as f:
-            for row in dropped_rows:
+            for row in new_rows:
                 f.write(json.dumps(row) + "\n")
-        logger.info(
-            "Quarantined %d unexpectedly-dropped session(s) to %s",
-            len(dropped_rows),
-            QUARANTINE_FILE,
-        )
+        if skipped:
+            logger.info(
+                "Quarantined %d new session(s) (skipped %d already "
+                "present) to %s",
+                len(new_rows), skipped, QUARANTINE_FILE,
+            )
+        else:
+            logger.info(
+                "Quarantined %d unexpectedly-dropped session(s) to %s",
+                len(new_rows), QUARANTINE_FILE,
+            )
     except OSError as exc:
         logger.error(
             "Could not write quarantine file %s: %s", QUARANTINE_FILE, exc
@@ -294,7 +391,18 @@ def upsert_sessions(
     clause captures every id PG touched; anything missing from that set
     is an unexpected drop (#55).
     """
-    input_count = len(rows)
+    # Within-batch dedup: multiple metadata files for the same session
+    # id would otherwise let only the last one "win" via ON CONFLICT DO
+    # UPDATE, misleadingly flagging the earlier occurrences as drops.
+    # Collapse to the last occurrence explicitly.
+    by_id: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        sid = row.get("id")
+        if sid:
+            by_id[sid] = row
+    deduped_rows = list(by_id.values())
+    duplicates_within_batch = len(rows) - len(deduped_rows)
+    input_count = len(deduped_rows)
 
     try:
         import psycopg2
@@ -309,6 +417,7 @@ def upsert_sessions(
             expected_dupes=0,
             unexpected_drops=[],
             db_available=False,
+            duplicates_within_batch=duplicates_within_batch,
         )
 
     columns = [
@@ -339,16 +448,13 @@ def upsert_sessions(
         RETURNING id
     """
 
-    # Convert rows to tuples in column order
-    values = []
-    for row in rows:
-        values.append(tuple(row[c] for c in columns))
-
-    input_ids = [row["id"] for row in rows]
+    # Convert deduped rows to tuples in column order
+    values = [tuple(row[c] for c in columns) for row in deduped_rows]
+    input_ids = [row["id"] for row in deduped_rows]
 
     try:
         conn = psycopg2.connect(dbname=DB_NAME)
-    except Exception as exc:
+    except psycopg2.OperationalError as exc:
         logger.warning("Cannot connect to PostgreSQL: %s", exc)
         logger.info(
             "PostgreSQL may be stopped — session.meta.json files remain canonical."
@@ -359,6 +465,7 @@ def upsert_sessions(
             expected_dupes=0,
             unexpected_drops=[],
             db_available=False,
+            duplicates_within_batch=duplicates_within_batch,
         )
 
     try:
@@ -381,14 +488,30 @@ def upsert_sessions(
             expected_dupes=0,
             unexpected_drops=unexpected_drops,
             db_available=True,
+            duplicates_within_batch=duplicates_within_batch,
         )
 
-        logger.info(
-            "Upsert accounting: input=%d inserted=%d unexpected_drops=%d",
-            result.input_count,
-            result.inserted,
-            len(result.unexpected_drops),
+        # DEBUG on the happy path (nothing to notice); INFO when something
+        # actually landed or when an anomaly surfaced.
+        accounting_msg = (
+            "Upsert accounting: input=%d inserted=%d unexpected_drops=%d "
+            "dupes_in_batch=%d"
         )
+        accounting_args = (
+            result.input_count, result.inserted,
+            len(result.unexpected_drops), result.duplicates_within_batch,
+        )
+        if unexpected_drops or duplicates_within_batch or result.inserted:
+            logger.info(accounting_msg, *accounting_args)
+        else:
+            logger.debug(accounting_msg, *accounting_args)
+
+        if duplicates_within_batch:
+            logger.warning(
+                "Input batch contained %d within-batch duplicate session "
+                "id(s); last occurrence won.",
+                duplicates_within_batch,
+            )
         if unexpected_drops:
             logger.error(
                 "Unexpectedly dropped %d session id(s) — not returned "
@@ -397,7 +520,7 @@ def upsert_sessions(
                 unexpected_drops[:10],
             )
         return result
-    except Exception as exc:
+    except psycopg2.Error as exc:
         logger.error("Database error during upsert: %s", exc)
         return InsertResult(
             input_count=input_count,
@@ -405,6 +528,7 @@ def upsert_sessions(
             expected_dupes=0,
             unexpected_drops=[],
             db_available=False,
+            duplicates_within_batch=duplicates_within_batch,
         )
     finally:
         conn.close()
@@ -422,7 +546,23 @@ def sync(
     """
     Run one sync cycle: find new session.meta.json files, upsert into
     PostgreSQL, update cursor.
+
+    Serialised against concurrent runs via a PG advisory lock; if another
+    sessions-sync is in progress, this one exits without touching the
+    cursor.
     """
+    with _sync_advisory_lock(logger) as acquired:
+        if not acquired:
+            return
+        _sync_locked(archive_root, full_resync, logger)
+
+
+def _sync_locked(
+    archive_root: Path,
+    full_resync: bool,
+    logger: logging.Logger,
+) -> None:
+    """Core sync cycle, executed under the advisory lock."""
     since = None if full_resync else load_cursor()
     if since:
         logger.info("Syncing sessions archived after %s", since)

--- a/scripts/sync-sessions-to-postgres.py
+++ b/scripts/sync-sessions-to-postgres.py
@@ -23,7 +23,7 @@ import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 # ============================================================================
 # Configuration
@@ -34,6 +34,10 @@ DEFAULT_ARCHIVE_ROOT = Path.home() / "cc-archives"
 LOG_DIR = PA_DIR / "logs"
 LOG_FILE = LOG_DIR / "sync-sessions.log"
 CURSOR_FILE = PA_DIR / "memories" / "sync-cursors.json"
+# Quarantine destination for rows silently dropped by the upsert. Lives
+# in the data submodule but we do not commit submodule pointer changes
+# as part of this fix (#55).
+QUARANTINE_FILE = PA_DIR / "data" / "sessions" / "quarantine-postgres-drops.jsonl"
 DB_NAME = "claude_memories"
 
 CURSOR_KEY = "sessions_sync_timestamp"
@@ -229,18 +233,69 @@ def metadata_to_row(
 # Database operations
 # ============================================================================
 
+class InsertResult(NamedTuple):
+    """
+    Accounting result for a session upsert batch.
+
+    Attributes:
+        input_count: Number of rows the caller handed us.
+        inserted: Number of rows returned by the upsert (should equal
+            input_count under DO UPDATE — any shortfall is anomalous).
+        expected_dupes: Always 0 for DO UPDATE — kept for shape parity
+            with the memory sync's InsertResult so callers can share
+            logic if needed later.
+        unexpected_drops: Ids in the input that did not appear in
+            RETURNING. Under DO UPDATE these should never exist;
+            anything here is a hard stop (#55).
+        db_available: False when we could not reach the database.
+    """
+
+    input_count: int
+    inserted: int
+    expected_dupes: int
+    unexpected_drops: list[str]
+    db_available: bool
+
+
+def _write_quarantine(
+    dropped_rows: list[dict[str, Any]],
+    logger: logging.Logger,
+) -> None:
+    """
+    Append dropped session rows to the quarantine JSONL.
+
+    Creates parent directories and the file if missing.
+    """
+    try:
+        QUARANTINE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with QUARANTINE_FILE.open("a", encoding="utf-8") as f:
+            for row in dropped_rows:
+                f.write(json.dumps(row) + "\n")
+        logger.info(
+            "Quarantined %d unexpectedly-dropped session(s) to %s",
+            len(dropped_rows),
+            QUARANTINE_FILE,
+        )
+    except OSError as exc:
+        logger.error(
+            "Could not write quarantine file %s: %s", QUARANTINE_FILE, exc
+        )
+
+
 def upsert_sessions(
     rows: list[dict[str, Any]],
     logger: logging.Logger,
-) -> int:
+) -> InsertResult:
     """
-    Upsert session rows into PostgreSQL.
+    Upsert session rows into PostgreSQL with full accounting.
 
-    Uses ON CONFLICT (id) DO UPDATE so that enriched metadata
-    (e.g. after cc-session update) replaces the previous version.
-
-    Returns the number of rows upserted.
+    Uses ON CONFLICT (id) DO UPDATE so enriched metadata (e.g. after
+    cc-session update) replaces the previous version. The RETURNING
+    clause captures every id PG touched; anything missing from that set
+    is an unexpected drop (#55).
     """
+    input_count = len(rows)
+
     try:
         import psycopg2
         from psycopg2.extras import execute_values
@@ -248,7 +303,13 @@ def upsert_sessions(
         logger.error(
             "psycopg2 not installed. Run: venv/bin/pip install psycopg2-binary"
         )
-        return 0
+        return InsertResult(
+            input_count=input_count,
+            inserted=0,
+            expected_dupes=0,
+            unexpected_drops=[],
+            db_available=False,
+        )
 
     columns = [
         "id", "project", "project_directory", "title", "purpose", "tags",
@@ -275,12 +336,15 @@ def upsert_sessions(
         INSERT INTO sessions ({', '.join(columns)})
         VALUES %s
         ON CONFLICT (id) DO UPDATE SET {update_set}
+        RETURNING id
     """
 
     # Convert rows to tuples in column order
     values = []
     for row in rows:
         values.append(tuple(row[c] for c in columns))
+
+    input_ids = [row["id"] for row in rows]
 
     try:
         conn = psycopg2.connect(dbname=DB_NAME)
@@ -289,17 +353,59 @@ def upsert_sessions(
         logger.info(
             "PostgreSQL may be stopped — session.meta.json files remain canonical."
         )
-        return 0
+        return InsertResult(
+            input_count=input_count,
+            inserted=0,
+            expected_dupes=0,
+            unexpected_drops=[],
+            db_available=False,
+        )
 
     try:
         with conn:
             with conn.cursor() as cur:
-                execute_values(cur, upsert_sql, values, page_size=50)
-        logger.info("Upserted %d sessions into PostgreSQL", len(rows))
-        return len(rows)
+                returned = execute_values(
+                    cur,
+                    upsert_sql,
+                    values,
+                    page_size=50,
+                    fetch=True,
+                )
+                returned_ids = {row[0] for row in returned}
+
+        unexpected_drops = [mid for mid in input_ids if mid not in returned_ids]
+
+        result = InsertResult(
+            input_count=input_count,
+            inserted=len(returned_ids),
+            expected_dupes=0,
+            unexpected_drops=unexpected_drops,
+            db_available=True,
+        )
+
+        logger.info(
+            "Upsert accounting: input=%d inserted=%d unexpected_drops=%d",
+            result.input_count,
+            result.inserted,
+            len(result.unexpected_drops),
+        )
+        if unexpected_drops:
+            logger.error(
+                "Unexpectedly dropped %d session id(s) — not returned "
+                "by DO UPDATE. First 10: %s",
+                len(unexpected_drops),
+                unexpected_drops[:10],
+            )
+        return result
     except Exception as exc:
         logger.error("Database error during upsert: %s", exc)
-        return 0
+        return InsertResult(
+            input_count=input_count,
+            inserted=0,
+            expected_dupes=0,
+            unexpected_drops=[],
+            db_available=False,
+        )
     finally:
         conn.close()
 
@@ -354,17 +460,34 @@ def sync(
         logger.info("No valid sessions to upsert")
         return
 
-    # Upsert into PostgreSQL
-    upserted = upsert_sessions(rows, logger)
+    # Upsert into PostgreSQL (returns InsertResult with full accounting).
+    result = upsert_sessions(rows, logger)
 
-    # Advance cursor only if upsert succeeded
-    if upserted > 0:
+    # Cursor advance policy (#55): advance ONLY when DB was reachable AND
+    # every input id appeared in RETURNING.
+    if not result.db_available:
+        logger.warning(
+            "Upsert returned db_available=False — cursor NOT advanced "
+            "(PostgreSQL may be down)"
+        )
+    elif result.unexpected_drops:
+        rows_by_id = {row["id"]: row for row in rows}
+        dropped_rows = [
+            rows_by_id[mid]
+            for mid in result.unexpected_drops
+            if mid in rows_by_id
+        ]
+        _write_quarantine(dropped_rows, logger)
+        logger.error(
+            "Cursor NOT advanced — %d session id(s) were silently dropped "
+            "by the upsert. Dropped ids: %s",
+            len(result.unexpected_drops),
+            result.unexpected_drops[:10],
+        )
+        return
+    else:
         save_cursor(latest_archived_at)
         logger.info("Cursor advanced to %s", latest_archived_at)
-    else:
-        logger.warning(
-            "Upsert returned 0 — cursor NOT advanced (PostgreSQL may be down)"
-        )
 
 
 def main() -> None:

--- a/scripts/sync-to-postgres.py
+++ b/scripts/sync-to-postgres.py
@@ -16,7 +16,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 # Optional embedding support — gracefully degrades if unavailable
 try:
@@ -38,6 +38,10 @@ MEMORIES_FILE = PA_DIR / "memories" / "memories.jsonl"
 CURSOR_FILE = PA_DIR / "memories" / "sync-cursors.json"
 LOG_DIR = PA_DIR / "logs"
 LOG_FILE = LOG_DIR / "sync.log"
+# Quarantine destination for rows silently dropped by ON CONFLICT.
+# Lives in the data submodule but the *write* is fine — we just do not
+# commit submodule pointer changes as part of this fix (#55).
+QUARANTINE_FILE = PA_DIR / "data" / "memories" / "quarantine-postgres-drops.jsonl"
 DB_NAME = "claude_memories"
 
 # All fields we extract from JSONL and insert into PostgreSQL
@@ -197,15 +201,76 @@ def record_to_tuple(record: dict[str, Any]) -> tuple:
 # Database operations
 # ============================================================================
 
-def insert_memories(records: list[tuple], logger: logging.Logger) -> int:
+class InsertResult(NamedTuple):
     """
-    Insert memory records into PostgreSQL.
+    Accounting result for a single insert batch.
 
-    Uses execute_values for batch efficiency. ON CONFLICT (id) DO NOTHING
-    handles re-syncs gracefully.
-
-    Returns the number of rows actually inserted.
+    Attributes:
+        input_count: Number of records the caller handed us.
+        inserted: Number of rows PG actually inserted (from RETURNING).
+        expected_dupes: Rows already present at pre-flight — ON CONFLICT
+            was expected to skip these, so they are not anomalies.
+        unexpected_drops: Ids that were neither present pre-flight nor
+            returned by INSERT. These indicate silent row loss (#55).
+        db_available: False when we could not reach the database.
     """
+
+    input_count: int
+    inserted: int
+    expected_dupes: int
+    unexpected_drops: list[str]
+    db_available: bool
+
+
+def _write_quarantine(
+    dropped_records: list[dict[str, Any]],
+    logger: logging.Logger,
+) -> None:
+    """
+    Append dropped memory records to the quarantine JSONL.
+
+    Creates parent directories and the file if missing. We quarantine
+    the *full records* (not just ids) so the drop can be diagnosed and
+    replayed without consulting the canonical.
+    """
+    try:
+        QUARANTINE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with QUARANTINE_FILE.open("a", encoding="utf-8") as f:
+            for rec in dropped_records:
+                f.write(json.dumps(rec) + "\n")
+        logger.info(
+            "Quarantined %d unexpectedly-dropped record(s) to %s",
+            len(dropped_records),
+            QUARANTINE_FILE,
+        )
+    except OSError as exc:
+        logger.error(
+            "Could not write quarantine file %s: %s", QUARANTINE_FILE, exc
+        )
+
+
+def insert_memories(
+    records: list[tuple],
+    logger: logging.Logger,
+) -> InsertResult:
+    """
+    Insert memory records into PostgreSQL with full accounting.
+
+    Workflow:
+      1. Pre-flight: SELECT existing ids so we know what ON CONFLICT is
+         *supposed* to skip (expected duplicates).
+      2. INSERT ... ON CONFLICT DO NOTHING RETURNING id, capturing the
+         set of ids PG actually inserted.
+      3. Classify every input id as inserted, expected-dupe, or
+         unexpected-drop.
+
+    Returns an :class:`InsertResult` so callers can decide whether to
+    advance the sync cursor. Callers MUST treat ``unexpected_drops``
+    non-empty as a hard stop — those rows never landed and skipping
+    them would cause silent loss (#55).
+    """
+    input_count = len(records)
+
     try:
         import psycopg2
         from psycopg2.extras import execute_values
@@ -213,16 +278,13 @@ def insert_memories(records: list[tuple], logger: logging.Logger) -> int:
         logger.error(
             "psycopg2 not installed. Run: venv/bin/pip install psycopg2-binary"
         )
-        return 0
-
-    insert_sql = """
-        INSERT INTO memories (
-            id, session_id, project, source, category, content, summary,
-            confidence, research_tags, zotero_key, source_context,
-            created_at, deadline_at
-        ) VALUES %s
-        ON CONFLICT (id) DO NOTHING
-    """
+        return InsertResult(
+            input_count=input_count,
+            inserted=0,
+            expected_dupes=0,
+            unexpected_drops=[],
+            db_available=False,
+        )
 
     try:
         conn = psycopg2.connect(dbname=DB_NAME)
@@ -232,22 +294,87 @@ def insert_memories(records: list[tuple], logger: logging.Logger) -> int:
             "PostgreSQL may be stopped — this is not critical. "
             "JSONL remains canonical."
         )
-        return 0
+        return InsertResult(
+            input_count=input_count,
+            inserted=0,
+            expected_dupes=0,
+            unexpected_drops=[],
+            db_available=False,
+        )
+
+    input_ids = [r[0] for r in records]
+
+    insert_sql = """
+        INSERT INTO memories (
+            id, session_id, project, source, category, content, summary,
+            confidence, research_tags, zotero_key, source_context,
+            created_at, deadline_at
+        ) VALUES %s
+        ON CONFLICT (id) DO NOTHING
+        RETURNING id
+    """
 
     try:
         with conn:
             with conn.cursor() as cur:
-                # execute_values with ON CONFLICT returns only the last
-                # batch's rowcount, so we count processed records instead
-                execute_values(cur, insert_sql, records, page_size=100)
-        logger.info(
-            "Sent %d memories to PostgreSQL (duplicates skipped via ON CONFLICT)",
-            len(records),
+                # Pre-flight: which of our input ids are already in PG?
+                # These are the rows ON CONFLICT is expected to skip.
+                cur.execute(
+                    "SELECT id FROM memories WHERE id = ANY(%s)",
+                    (input_ids,),
+                )
+                present_before = {row[0] for row in cur.fetchall()}
+
+                # Insert with RETURNING to capture what PG actually took.
+                returned = execute_values(
+                    cur,
+                    insert_sql,
+                    records,
+                    page_size=100,
+                    fetch=True,
+                )
+                returned_ids = {row[0] for row in returned}
+
+        # Preserve input order when reporting unexpected drops.
+        unexpected_drops = [
+            mid
+            for mid in input_ids
+            if mid not in present_before and mid not in returned_ids
+        ]
+
+        result = InsertResult(
+            input_count=input_count,
+            inserted=len(returned_ids),
+            expected_dupes=len(present_before),
+            unexpected_drops=unexpected_drops,
+            db_available=True,
         )
-        return len(records)
+
+        logger.info(
+            "Insert accounting: input=%d inserted=%d expected_dupes=%d "
+            "unexpected_drops=%d",
+            result.input_count,
+            result.inserted,
+            result.expected_dupes,
+            len(result.unexpected_drops),
+        )
+        if unexpected_drops:
+            logger.error(
+                "Unexpectedly dropped %d id(s) — neither pre-existing "
+                "nor inserted. First 10: %s",
+                len(unexpected_drops),
+                unexpected_drops[:10],
+            )
+        return result
     except Exception as exc:
         logger.error("Database error during insert: %s", exc)
-        return 0
+        return InsertResult(
+            input_count=input_count,
+            inserted=0,
+            expected_dupes=0,
+            unexpected_drops=[],
+            db_available=False,
+        )
     finally:
         conn.close()
 
@@ -411,31 +538,52 @@ def sync(logger: logging.Logger) -> None:
         cursor_line + 1, total_lines, len(new_lines),
     )
 
-    # Parse records
-    records = []
+    # Parse records. We keep both the original dict (for quarantine on
+    # unexpected drop) and the INSERT tuple (for psycopg2), indexed by id.
+    records: list[tuple] = []
+    parsed_by_id: dict[str, dict[str, Any]] = {}
     for offset, line in enumerate(new_lines):
         line_number = cursor_line + offset + 1  # 1-based for logging
         parsed = parse_jsonl_record(line, line_number, logger)
         if parsed is not None:
             records.append(record_to_tuple(parsed))
+            parsed_by_id[parsed["id"]] = parsed
 
     if not records:
         logger.info("No valid records to insert")
         save_cursor(total_lines)
         return
 
-    # Insert into PostgreSQL
-    inserted = insert_memories(records, logger)
+    # Insert into PostgreSQL (returns InsertResult with full accounting).
+    result = insert_memories(records, logger)
 
-    # Only advance cursor if insertion succeeded
-    if inserted > 0:
+    # Cursor advance policy (#55): advance ONLY when we have positive
+    # evidence every input row is accounted for. Specifically:
+    #   - DB was reachable, AND
+    #   - no ids fell through both pre-flight and RETURNING.
+    if not result.db_available:
+        logger.warning(
+            "Insert returned db_available=False — cursor NOT advanced "
+            "(PostgreSQL may be down)"
+        )
+    elif result.unexpected_drops:
+        dropped_records = [
+            parsed_by_id[mid]
+            for mid in result.unexpected_drops
+            if mid in parsed_by_id
+        ]
+        _write_quarantine(dropped_records, logger)
+        logger.error(
+            "Cursor NOT advanced — %d id(s) were silently dropped by "
+            "ON CONFLICT. Dropped ids: %s",
+            len(result.unexpected_drops),
+            result.unexpected_drops[:10],
+        )
+        return
+    else:
         save_cursor(total_lines)
         save_sync_timestamp()
         logger.info("Cursor advanced to line %d", total_lines)
-    else:
-        logger.warning(
-            "Insert returned 0 — cursor NOT advanced (PostgreSQL may be down)"
-        )
 
     # Best-effort embedding of memories with NULL embeddings.
     # Processes up to EMBED_BATCH_SIZE per sync cycle (~100ms overhead).

--- a/scripts/sync-to-postgres.py
+++ b/scripts/sync-to-postgres.py
@@ -15,8 +15,9 @@ Usage:
 import json
 import logging
 import sys
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import Any, Iterator, NamedTuple, Optional
 
 # Optional embedding support — gracefully degrades if unavailable
 try:
@@ -43,6 +44,10 @@ LOG_FILE = LOG_DIR / "sync.log"
 # commit submodule pointer changes as part of this fix (#55).
 QUARANTINE_FILE = PA_DIR / "data" / "memories" / "quarantine-postgres-drops.jsonl"
 DB_NAME = "claude_memories"
+# Advisory-lock key for serialising concurrent sync runs. PG hashes the
+# string to a 32-bit int; `pg_try_advisory_lock` is session-scoped and
+# auto-releases when the connection closes.
+ADVISORY_LOCK_KEY = "sync-to-postgres"
 
 # All fields we extract from JSONL and insert into PostgreSQL
 JSONL_FIELDS = [
@@ -206,13 +211,17 @@ class InsertResult(NamedTuple):
     Accounting result for a single insert batch.
 
     Attributes:
-        input_count: Number of records the caller handed us.
+        input_count: Number of records attempted after within-batch
+            dedup (see ``duplicates_within_batch``).
         inserted: Number of rows PG actually inserted (from RETURNING).
         expected_dupes: Rows already present at pre-flight — ON CONFLICT
             was expected to skip these, so they are not anomalies.
         unexpected_drops: Ids that were neither present pre-flight nor
             returned by INSERT. These indicate silent row loss (#55).
         db_available: False when we could not reach the database.
+        duplicates_within_batch: Input records that shared an id with
+            another record in the same batch; the last occurrence won.
+            Non-zero here usually indicates canonical corruption.
     """
 
     input_count: int
@@ -220,6 +229,85 @@ class InsertResult(NamedTuple):
     expected_dupes: int
     unexpected_drops: list[str]
     db_available: bool
+    duplicates_within_batch: int = 0
+
+
+@contextmanager
+def _sync_advisory_lock(logger: logging.Logger) -> Iterator[bool]:
+    """
+    Acquire a PostgreSQL session-scoped advisory lock for the sync cycle.
+
+    Yields True when the sync should proceed, False when another sync
+    already holds the lock and this run should defer to the next cron
+    tick. The lock auto-releases when the backing connection closes.
+
+    If psycopg2 is missing or the database is unreachable, yields True
+    unconditionally — those cases are handled by the insert path, which
+    logs appropriately and leaves the cursor alone.
+
+    This prevents the race where two overlapping sync runs both see the
+    same ids as missing from pre-flight, both attempt INSERT, and the
+    loser classifies the winner's rows as unexpected_drops (#55).
+    """
+    try:
+        import psycopg2
+    except ImportError:
+        yield True
+        return
+
+    try:
+        conn = psycopg2.connect(dbname=DB_NAME)
+    except psycopg2.OperationalError:
+        yield True
+        return
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_try_advisory_lock(hashtext(%s))",
+                (ADVISORY_LOCK_KEY,),
+            )
+            acquired = bool(cur.fetchone()[0])
+        conn.commit()  # end txn; session-scoped lock persists on conn
+        if not acquired:
+            logger.warning(
+                "Another sync holds the advisory lock for %r — skipping "
+                "this cycle. Will retry on next tick.",
+                ADVISORY_LOCK_KEY,
+            )
+            yield False
+            return
+        yield True
+    finally:
+        conn.close()  # releases the lock if we hold it
+
+
+def _load_quarantined_ids() -> set[str]:
+    """
+    Return the set of ids already present in the quarantine JSONL.
+
+    Used to avoid appending duplicate rows on repeated cron runs. When
+    the cursor halts, subsequent ticks re-read the same input slice and
+    would otherwise quarantine the same ids over and over. Malformed
+    lines are skipped silently — the quarantine file is a diagnostic
+    log, not load-bearing.
+    """
+    if not QUARANTINE_FILE.exists():
+        return set()
+    ids: set[str] = set()
+    with QUARANTINE_FILE.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+                mid = rec.get("id")
+                if isinstance(mid, str):
+                    ids.add(mid)
+            except json.JSONDecodeError:
+                continue
+    return ids
 
 
 def _write_quarantine(
@@ -229,20 +317,39 @@ def _write_quarantine(
     """
     Append dropped memory records to the quarantine JSONL.
 
-    Creates parent directories and the file if missing. We quarantine
+    Creates parent directories and the file if missing. Deduplicates
+    against already-quarantined ids so repeated cron runs against the
+    same halted cursor do not grow the file linearly. We quarantine
     the *full records* (not just ids) so the drop can be diagnosed and
     replayed without consulting the canonical.
     """
+    already = _load_quarantined_ids()
+    new_records = [
+        r for r in dropped_records if r.get("id") not in already
+    ]
+    if not new_records:
+        logger.info(
+            "All %d dropped record(s) already in quarantine — no new appends",
+            len(dropped_records),
+        )
+        return
+    skipped = len(dropped_records) - len(new_records)
     try:
         QUARANTINE_FILE.parent.mkdir(parents=True, exist_ok=True)
         with QUARANTINE_FILE.open("a", encoding="utf-8") as f:
-            for rec in dropped_records:
+            for rec in new_records:
                 f.write(json.dumps(rec) + "\n")
-        logger.info(
-            "Quarantined %d unexpectedly-dropped record(s) to %s",
-            len(dropped_records),
-            QUARANTINE_FILE,
-        )
+        if skipped:
+            logger.info(
+                "Quarantined %d new record(s) (skipped %d already present) "
+                "to %s",
+                len(new_records), skipped, QUARANTINE_FILE,
+            )
+        else:
+            logger.info(
+                "Quarantined %d unexpectedly-dropped record(s) to %s",
+                len(new_records), QUARANTINE_FILE,
+            )
     except OSError as exc:
         logger.error(
             "Could not write quarantine file %s: %s", QUARANTINE_FILE, exc
@@ -257,11 +364,13 @@ def insert_memories(
     Insert memory records into PostgreSQL with full accounting.
 
     Workflow:
-      1. Pre-flight: SELECT existing ids so we know what ON CONFLICT is
+      1. Dedupe the input batch by id (last occurrence wins) so that
+         within-batch duplicates are not misclassified as drops.
+      2. Pre-flight: SELECT existing ids so we know what ON CONFLICT is
          *supposed* to skip (expected duplicates).
-      2. INSERT ... ON CONFLICT DO NOTHING RETURNING id, capturing the
+      3. INSERT ... ON CONFLICT DO NOTHING RETURNING id, capturing the
          set of ids PG actually inserted.
-      3. Classify every input id as inserted, expected-dupe, or
+      4. Classify every input id as inserted, expected-dupe, or
          unexpected-drop.
 
     Returns an :class:`InsertResult` so callers can decide whether to
@@ -269,7 +378,16 @@ def insert_memories(
     non-empty as a hard stop — those rows never landed and skipping
     them would cause silent loss (#55).
     """
-    input_count = len(records)
+    # Within-batch dedup: if the same id appears twice in ``records``,
+    # only the last occurrence would "win" in PG anyway (subsequent
+    # inserts against the just-inserted row conflict). Collapse here so
+    # ``input_count`` and the set-based classification stay consistent.
+    by_id: dict[str, tuple] = {}
+    for rec in records:
+        by_id[rec[0]] = rec
+    deduped_records = list(by_id.values())
+    duplicates_within_batch = len(records) - len(deduped_records)
+    input_count = len(deduped_records)
 
     try:
         import psycopg2
@@ -284,6 +402,7 @@ def insert_memories(
             expected_dupes=0,
             unexpected_drops=[],
             db_available=False,
+            duplicates_within_batch=duplicates_within_batch,
         )
 
     try:
@@ -300,9 +419,10 @@ def insert_memories(
             expected_dupes=0,
             unexpected_drops=[],
             db_available=False,
+            duplicates_within_batch=duplicates_within_batch,
         )
 
-    input_ids = [r[0] for r in records]
+    input_ids = [r[0] for r in deduped_records]
 
     insert_sql = """
         INSERT INTO memories (
@@ -319,6 +439,9 @@ def insert_memories(
             with conn.cursor() as cur:
                 # Pre-flight: which of our input ids are already in PG?
                 # These are the rows ON CONFLICT is expected to skip.
+                # ANY(%s) sends the list as a single PG array parameter,
+                # so we are not limited by the ~32k per-statement parameter
+                # ceiling — batches of 100k ids would still fit.
                 cur.execute(
                     "SELECT id FROM memories WHERE id = ANY(%s)",
                     (input_ids,),
@@ -329,7 +452,7 @@ def insert_memories(
                 returned = execute_values(
                     cur,
                     insert_sql,
-                    records,
+                    deduped_records,
                     page_size=100,
                     fetch=True,
                 )
@@ -348,16 +471,33 @@ def insert_memories(
             expected_dupes=len(present_before),
             unexpected_drops=unexpected_drops,
             db_available=True,
+            duplicates_within_batch=duplicates_within_batch,
         )
 
-        logger.info(
+        # Keep the happy path quiet; escalate only when there is
+        # something a human might want to see. Pure re-sync cycles
+        # (all expected_dupes) emit at DEBUG; anything anomalous or
+        # novel is logged at INFO.
+        accounting_msg = (
             "Insert accounting: input=%d inserted=%d expected_dupes=%d "
-            "unexpected_drops=%d",
-            result.input_count,
-            result.inserted,
-            result.expected_dupes,
-            len(result.unexpected_drops),
+            "unexpected_drops=%d dupes_in_batch=%d"
         )
+        accounting_args = (
+            result.input_count, result.inserted, result.expected_dupes,
+            len(result.unexpected_drops), result.duplicates_within_batch,
+        )
+        if unexpected_drops or duplicates_within_batch or result.inserted:
+            logger.info(accounting_msg, *accounting_args)
+        else:
+            logger.debug(accounting_msg, *accounting_args)
+
+        if duplicates_within_batch:
+            logger.warning(
+                "Input batch contained %d within-batch duplicate id(s); "
+                "last occurrence of each id won. Check canonical JSONL "
+                "for corruption.",
+                duplicates_within_batch,
+            )
         if unexpected_drops:
             logger.error(
                 "Unexpectedly dropped %d id(s) — neither pre-existing "
@@ -366,7 +506,7 @@ def insert_memories(
                 unexpected_drops[:10],
             )
         return result
-    except Exception as exc:
+    except psycopg2.Error as exc:
         logger.error("Database error during insert: %s", exc)
         return InsertResult(
             input_count=input_count,
@@ -374,6 +514,7 @@ def insert_memories(
             expected_dupes=0,
             unexpected_drops=[],
             db_available=False,
+            duplicates_within_batch=duplicates_within_batch,
         )
     finally:
         conn.close()
@@ -511,6 +652,10 @@ def sync(logger: logging.Logger) -> None:
     """
     Run one sync cycle: read new JSONL lines, insert into PostgreSQL,
     update cursor.
+
+    Serialised against concurrent runs via a PG advisory lock; if another
+    sync is in progress, this one exits without touching the cursor and
+    the next cron tick retries.
     """
     if not MEMORIES_FILE.exists():
         logger.warning("Memories file not found: %s", MEMORIES_FILE)
@@ -518,6 +663,14 @@ def sync(logger: logging.Logger) -> None:
 
     check_canonical_for_duplicates(logger)
 
+    with _sync_advisory_lock(logger) as acquired:
+        if not acquired:
+            return
+        _sync_locked(logger)
+
+
+def _sync_locked(logger: logging.Logger) -> None:
+    """Core sync cycle, executed under the advisory lock."""
     cursor_line = load_cursor()
 
     # Read all lines and process from cursor position

--- a/tests/test_audit_postgres_sync.py
+++ b/tests/test_audit_postgres_sync.py
@@ -1,0 +1,144 @@
+"""
+Smoke tests for scripts/audit-postgres-sync.py.
+
+Covers JSONL id extraction, archive id extraction, and the AuditResult
+``is_clean`` predicate without touching a real PostgreSQL instance.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import the audit module (hyphenated filename requires importlib).
+# Register in sys.modules before exec so that @dataclass can look up the
+# module's namespace during class construction.
+_audit_path = (
+    Path(__file__).parent.parent / "scripts" / "audit-postgres-sync.py"
+)
+_spec = importlib.util.spec_from_file_location("audit_postgres_sync", _audit_path)
+audit_mod = importlib.util.module_from_spec(_spec)
+sys.modules["audit_postgres_sync"] = audit_mod
+_spec.loader.exec_module(audit_mod)
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    """Quiet logger for test runs."""
+    return logging.getLogger("test-audit")
+
+
+class TestReadJsonlIds:
+    """Canonical id extraction from a JSONL file."""
+
+    def test_collects_all_ids(self, tmp_path: Path, logger: logging.Logger) -> None:
+        """Every valid line contributes its id to the set."""
+        jsonl = tmp_path / "memories.jsonl"
+        jsonl.write_text(
+            "\n".join(
+                json.dumps({"id": f"mem-{i}", "content": "x"}) for i in range(3)
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        ids = audit_mod._read_jsonl_ids(jsonl, logger)
+        assert ids == {"mem-0", "mem-1", "mem-2"}
+
+    def test_dedupes_repeated_ids(
+        self, tmp_path: Path, logger: logging.Logger
+    ) -> None:
+        """Duplicate ids collapse to a single set entry."""
+        jsonl = tmp_path / "memories.jsonl"
+        jsonl.write_text(
+            json.dumps({"id": "dup"}) + "\n" + json.dumps({"id": "dup"}) + "\n",
+            encoding="utf-8",
+        )
+        ids = audit_mod._read_jsonl_ids(jsonl, logger)
+        assert ids == {"dup"}
+
+    def test_skips_blank_and_malformed(
+        self, tmp_path: Path, logger: logging.Logger
+    ) -> None:
+        """Blank lines and malformed JSON are tolerated."""
+        jsonl = tmp_path / "memories.jsonl"
+        jsonl.write_text(
+            "\n"
+            + "{not json\n"
+            + json.dumps({"id": "ok-1"}) + "\n"
+            + "   \n"
+            + json.dumps({"no_id": True}) + "\n"
+            + json.dumps({"id": "ok-2"}) + "\n",
+            encoding="utf-8",
+        )
+        ids = audit_mod._read_jsonl_ids(jsonl, logger)
+        assert ids == {"ok-1", "ok-2"}
+
+
+class TestReadArchiveIds:
+    """Canonical id extraction from session.meta.json files."""
+
+    def test_recurses_and_extracts(
+        self, tmp_path: Path, logger: logging.Logger
+    ) -> None:
+        """Session ids are found recursively beneath the archive root."""
+        for project, sid in [("proj-a", "sess-1"), ("proj-b", "sess-2")]:
+            d = tmp_path / project / "2026-04-23_xyz"
+            d.mkdir(parents=True)
+            (d / "session.meta.json").write_text(
+                json.dumps({"session": {"id": sid}}),
+                encoding="utf-8",
+            )
+
+        ids = audit_mod._read_session_archive_ids(tmp_path, logger)
+        assert ids == {"sess-1", "sess-2"}
+
+    def test_missing_root_returns_empty(
+        self, tmp_path: Path, logger: logging.Logger
+    ) -> None:
+        """A nonexistent archive root yields an empty set."""
+        ids = audit_mod._read_session_archive_ids(
+            tmp_path / "does-not-exist", logger
+        )
+        assert ids == set()
+
+
+class TestAuditResult:
+    """Semantics of the AuditResult container."""
+
+    def test_is_clean_when_no_canonical_missing(self) -> None:
+        """An empty only_in_canonical means the audit is clean."""
+        result = audit_mod.AuditResult(
+            source_name="memories",
+            canonical_count=10,
+            postgres_count=10,
+            only_in_canonical=[],
+            only_in_postgres=[],
+        )
+        assert result.is_clean is True
+
+    def test_not_clean_when_canonical_missing(self) -> None:
+        """Any canonical id missing from PG means the audit is dirty."""
+        result = audit_mod.AuditResult(
+            source_name="memories",
+            canonical_count=10,
+            postgres_count=9,
+            only_in_canonical=["missing-id"],
+            only_in_postgres=[],
+        )
+        assert result.is_clean is False
+
+    def test_pg_orphans_still_clean(self) -> None:
+        """Orphans in PG (only_in_postgres) do not fail the audit."""
+        result = audit_mod.AuditResult(
+            source_name="memories",
+            canonical_count=9,
+            postgres_count=10,
+            only_in_canonical=[],
+            only_in_postgres=["orphan"],
+        )
+        assert result.is_clean is True

--- a/tests/test_sync_script.py
+++ b/tests/test_sync_script.py
@@ -288,8 +288,12 @@ class TestFieldConsistency:
 # ============================================================================
 
 
-class _FakePsycopg2OperationalError(Exception):
-    """Stand-in for ``psycopg2.OperationalError`` in patched-sys.modules tests."""
+class _FakePsycopg2Error(Exception):
+    """Stand-in for ``psycopg2.Error`` — base class for all DB errors."""
+
+
+class _FakePsycopg2OperationalError(_FakePsycopg2Error):
+    """Stand-in for ``psycopg2.OperationalError`` (subclass of Error)."""
 
 
 def _install_fake_psycopg2(
@@ -298,28 +302,33 @@ def _install_fake_psycopg2(
     present_before_ids: list[str],
     returned_ids: list[str],
     raise_on_connect: bool = False,
+    advisory_lock_acquired: bool = True,
 ) -> MagicMock:
     """
     Install a fake ``psycopg2`` package into ``sys.modules`` that the
-    function-level import in ``insert_memories`` will pick up.
+    function-level import in ``insert_memories`` and the advisory-lock
+    helper will pick up.
 
     The mock controls:
       - the pre-flight SELECT result (``present_before_ids``)
       - the RETURNING result of ``execute_values`` (``returned_ids``)
       - whether ``psycopg2.connect`` raises an OperationalError
+      - whether ``pg_try_advisory_lock`` reports acquired (for the
+        contended-lock path)
 
     Returns the fake connection mock so callers can assert on usage.
     """
     fake_psycopg2 = types.ModuleType("psycopg2")
     fake_extras = types.ModuleType("psycopg2.extras")
 
-    # Operational error type must be a subclass of Exception for isinstance.
+    fake_psycopg2.Error = _FakePsycopg2Error
     fake_psycopg2.OperationalError = _FakePsycopg2OperationalError
 
-    # Cursor mock: different fetchall/fetchmany results for pre-flight vs
-    # execute_values. fetch on execute_values happens via its own return.
+    # Cursor mock: fetchall returns the pre-flight SELECT result;
+    # fetchone returns the advisory-lock boolean.
     cur = MagicMock()
     cur.fetchall.return_value = [(mid,) for mid in present_before_ids]
+    cur.fetchone.return_value = (advisory_lock_acquired,)
     cur.__enter__ = MagicMock(return_value=cur)
     cur.__exit__ = MagicMock(return_value=False)
 
@@ -522,3 +531,163 @@ class TestInsertMemoriesAccounting:
         if cursor_file.exists():
             data = json.loads(cursor_file.read_text())
             assert "postgres_sync_line" not in data or data["postgres_sync_line"] == 0
+
+    def test_within_batch_dedup_last_wins(
+        self, monkeypatch: pytest.MonkeyPatch, test_logger: logging.Logger
+    ) -> None:
+        """
+        Input batch with duplicate ids collapses to the last occurrence.
+        The ``duplicates_within_batch`` counter surfaces the collapse so
+        operators can see canonical-corruption signals without the
+        accounting line looking like a silent-drop event.
+        """
+        # Two records share id ``dup-a``; only the last should survive
+        # the within-batch dedup pass.
+        records = [
+            (
+                "dup-a", "sess", None, "extraction", "progress", "first",
+                None, "medium", [], None, "", "2026-04-23T00:00:00Z", None,
+            ),
+            (
+                "new-b", "sess", None, "extraction", "progress", "x",
+                None, "medium", [], None, "", "2026-04-23T00:00:00Z", None,
+            ),
+            (
+                "dup-a", "sess", None, "extraction", "progress", "second",
+                None, "medium", [], None, "", "2026-04-23T00:00:00Z", None,
+            ),
+        ]
+        _install_fake_psycopg2(
+            monkeypatch,
+            present_before_ids=[],
+            returned_ids=["dup-a", "new-b"],
+        )
+        result = sync_mod.insert_memories(records, test_logger)
+        assert result.db_available is True
+        assert result.duplicates_within_batch == 1
+        # Deduped input count: 2 unique ids (dup-a and new-b).
+        assert result.input_count == 2
+        assert result.inserted == 2
+        assert result.unexpected_drops == []
+
+    def test_quarantine_dedup_skips_already_present(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+        test_logger: logging.Logger,
+    ) -> None:
+        """
+        Repeated calls to _write_quarantine with the same id append
+        only once — the quarantine file does not grow linearly when the
+        cursor is halted and cron re-runs the same input slice.
+        """
+        quarantine = tmp_path / "quarantine.jsonl"
+        monkeypatch.setattr(sync_mod, "QUARANTINE_FILE", quarantine)
+
+        dropped = [{"id": "mem-x", "content": "payload"}]
+        sync_mod._write_quarantine(dropped, test_logger)
+        sync_mod._write_quarantine(dropped, test_logger)
+        sync_mod._write_quarantine(dropped, test_logger)
+
+        lines = [
+            json.loads(line) for line in quarantine.read_text().splitlines()
+            if line.strip()
+        ]
+        assert len(lines) == 1
+        assert lines[0]["id"] == "mem-x"
+
+    def test_quarantine_dedup_appends_new_only(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+        test_logger: logging.Logger,
+    ) -> None:
+        """Mixed new + already-quarantined input writes only the new ids."""
+        quarantine = tmp_path / "quarantine.jsonl"
+        monkeypatch.setattr(sync_mod, "QUARANTINE_FILE", quarantine)
+
+        sync_mod._write_quarantine(
+            [{"id": "old-1", "content": "a"}], test_logger
+        )
+        sync_mod._write_quarantine(
+            [{"id": "old-1", "content": "a"}, {"id": "new-2", "content": "b"}],
+            test_logger,
+        )
+
+        lines = [
+            json.loads(line) for line in quarantine.read_text().splitlines()
+            if line.strip()
+        ]
+        ids = {ln["id"] for ln in lines}
+        assert ids == {"old-1", "new-2"}
+        assert len(lines) == 2
+
+    def test_advisory_lock_contended_skips_sync(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        test_logger: logging.Logger,
+    ) -> None:
+        """
+        When another sync holds the advisory lock, sync() exits cleanly
+        without touching the cursor or calling insert_memories.
+        """
+        memories = tmp_path / "memories.jsonl"
+        memories.write_text(
+            json.dumps({
+                "id": "mem-a",
+                "category": "progress",
+                "content": "x",
+                "created_at": "2026-04-23T00:00:00Z",
+            }) + "\n",
+            encoding="utf-8",
+        )
+        cursor_file = tmp_path / "sync-cursors.json"
+
+        monkeypatch.setattr(sync_mod, "MEMORIES_FILE", memories)
+        monkeypatch.setattr(sync_mod, "CURSOR_FILE", cursor_file)
+        monkeypatch.setattr(sync_mod, "HAS_EMBED", False)
+
+        _install_fake_psycopg2(
+            monkeypatch,
+            present_before_ids=[],
+            returned_ids=["mem-a"],
+            advisory_lock_acquired=False,
+        )
+
+        # Spy on insert_memories — it must not be called when contended.
+        called = {"insert": False}
+        orig_insert = sync_mod.insert_memories
+
+        def _spy(records, logger):
+            called["insert"] = True
+            return orig_insert(records, logger)
+
+        monkeypatch.setattr(sync_mod, "insert_memories", _spy)
+
+        sync_mod.sync(test_logger)
+
+        assert called["insert"] is False
+        # Cursor key should not be set (or left at 0).
+        if cursor_file.exists():
+            data = json.loads(cursor_file.read_text())
+            assert data.get("postgres_sync_line", 0) == 0
+
+    def test_narrow_exception_reraises_non_psycopg_errors(
+        self, monkeypatch: pytest.MonkeyPatch, test_logger: logging.Logger
+    ) -> None:
+        """
+        The post-connect except clause catches psycopg2.Error only; a
+        KeyError from a malformed record bubbles up rather than being
+        disguised as ``db_available=False``. This lets programmer bugs
+        surface instead of being swallowed.
+        """
+        _install_fake_psycopg2(
+            monkeypatch,
+            present_before_ids=[],
+            returned_ids=[],
+        )
+        # Make execute_values raise a non-psycopg error.
+        sys.modules["psycopg2.extras"].execute_values = MagicMock(
+            side_effect=KeyError("missing column")
+        )
+        with pytest.raises(KeyError):
+            sync_mod.insert_memories(
+                self._make_records(["a"]), test_logger
+            )

--- a/tests/test_sync_script.py
+++ b/tests/test_sync_script.py
@@ -7,8 +7,11 @@ Tests pure functions only; does not require a running PostgreSQL instance.
 
 import importlib.util
 import json
+import logging
 import sys
+import types
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -278,3 +281,244 @@ class TestFieldConsistency:
     def test_source_in_fields(self):
         """The 'source' field must be present in JSONL_FIELDS."""
         assert "source" in sync_mod.JSONL_FIELDS
+
+
+# ============================================================================
+# Insert Accounting (#55 fix)
+# ============================================================================
+
+
+class _FakePsycopg2OperationalError(Exception):
+    """Stand-in for ``psycopg2.OperationalError`` in patched-sys.modules tests."""
+
+
+def _install_fake_psycopg2(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    present_before_ids: list[str],
+    returned_ids: list[str],
+    raise_on_connect: bool = False,
+) -> MagicMock:
+    """
+    Install a fake ``psycopg2`` package into ``sys.modules`` that the
+    function-level import in ``insert_memories`` will pick up.
+
+    The mock controls:
+      - the pre-flight SELECT result (``present_before_ids``)
+      - the RETURNING result of ``execute_values`` (``returned_ids``)
+      - whether ``psycopg2.connect`` raises an OperationalError
+
+    Returns the fake connection mock so callers can assert on usage.
+    """
+    fake_psycopg2 = types.ModuleType("psycopg2")
+    fake_extras = types.ModuleType("psycopg2.extras")
+
+    # Operational error type must be a subclass of Exception for isinstance.
+    fake_psycopg2.OperationalError = _FakePsycopg2OperationalError
+
+    # Cursor mock: different fetchall/fetchmany results for pre-flight vs
+    # execute_values. fetch on execute_values happens via its own return.
+    cur = MagicMock()
+    cur.fetchall.return_value = [(mid,) for mid in present_before_ids]
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+
+    if raise_on_connect:
+        fake_psycopg2.connect = MagicMock(
+            side_effect=_FakePsycopg2OperationalError("DB down")
+        )
+    else:
+        fake_psycopg2.connect = MagicMock(return_value=conn)
+
+    # execute_values returns RETURNING rows when fetch=True.
+    fake_extras.execute_values = MagicMock(
+        return_value=[(mid,) for mid in returned_ids]
+    )
+
+    monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+    monkeypatch.setitem(sys.modules, "psycopg2.extras", fake_extras)
+
+    return conn
+
+
+@pytest.fixture
+def test_logger() -> logging.Logger:
+    """Quiet logger for accountability tests."""
+    return logging.getLogger("test-sync")
+
+
+class TestInsertMemoriesAccounting:
+    """Row-level accounting for :func:`insert_memories` (#55)."""
+
+    def _make_records(self, ids: list[str]) -> list[tuple]:
+        """Build minimal INSERT tuples with the given ids."""
+        return [
+            (
+                mid, "sess", None, "extraction", "progress", "c",
+                None, "medium", [], None, "", "2026-04-23T00:00:00Z", None,
+            )
+            for mid in ids
+        ]
+
+    def test_all_new_rows_all_inserted(
+        self, monkeypatch: pytest.MonkeyPatch, test_logger: logging.Logger
+    ) -> None:
+        """Empty pre-flight + full RETURNING → clean insert, no drops."""
+        ids = ["new-a", "new-b", "new-c"]
+        _install_fake_psycopg2(
+            monkeypatch,
+            present_before_ids=[],
+            returned_ids=ids,
+        )
+        result = sync_mod.insert_memories(self._make_records(ids), test_logger)
+        assert result.db_available is True
+        assert result.input_count == 3
+        assert result.inserted == 3
+        assert result.expected_dupes == 0
+        assert result.unexpected_drops == []
+
+    def test_all_duplicates_all_expected(
+        self, monkeypatch: pytest.MonkeyPatch, test_logger: logging.Logger
+    ) -> None:
+        """All ids pre-existing, 0 returned → all expected dupes, no drops."""
+        ids = ["dup-a", "dup-b"]
+        _install_fake_psycopg2(
+            monkeypatch,
+            present_before_ids=ids,
+            returned_ids=[],
+        )
+        result = sync_mod.insert_memories(self._make_records(ids), test_logger)
+        assert result.db_available is True
+        assert result.inserted == 0
+        assert result.expected_dupes == 2
+        assert result.unexpected_drops == []
+
+    def test_mixed_new_and_expected_dupes(
+        self, monkeypatch: pytest.MonkeyPatch, test_logger: logging.Logger
+    ) -> None:
+        """N input, K pre-existing, N-K returned → counts correct, no drops."""
+        ids = ["dup-a", "new-b", "dup-c", "new-d"]
+        _install_fake_psycopg2(
+            monkeypatch,
+            present_before_ids=["dup-a", "dup-c"],
+            returned_ids=["new-b", "new-d"],
+        )
+        result = sync_mod.insert_memories(self._make_records(ids), test_logger)
+        assert result.db_available is True
+        assert result.input_count == 4
+        assert result.inserted == 2
+        assert result.expected_dupes == 2
+        assert result.unexpected_drops == []
+
+    def test_unexpected_drop_halts_cursor(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        test_logger: logging.Logger,
+    ) -> None:
+        """Id absent from both pre-flight and RETURNING → drop + no advance."""
+        # Point CURSOR_FILE and QUARANTINE_FILE into tmp_path and MEMORIES_FILE
+        # at a small stub so sync() can run end-to-end.
+        memories = tmp_path / "memories.jsonl"
+        memories.write_text(
+            json.dumps({
+                "id": "mem-a",
+                "category": "progress",
+                "content": "x",
+                "created_at": "2026-04-23T00:00:00Z",
+            }) + "\n"
+            + json.dumps({
+                "id": "mem-b",
+                "category": "progress",
+                "content": "y",
+                "created_at": "2026-04-23T00:00:00Z",
+            }) + "\n",
+            encoding="utf-8",
+        )
+        cursor_file = tmp_path / "sync-cursors.json"
+        quarantine = tmp_path / "quarantine.jsonl"
+
+        monkeypatch.setattr(sync_mod, "MEMORIES_FILE", memories)
+        monkeypatch.setattr(sync_mod, "CURSOR_FILE", cursor_file)
+        monkeypatch.setattr(sync_mod, "QUARANTINE_FILE", quarantine)
+        monkeypatch.setattr(sync_mod, "HAS_EMBED", False)
+
+        # mem-a absent both pre-flight and RETURNING → unexpected drop.
+        # mem-b returned normally.
+        _install_fake_psycopg2(
+            monkeypatch,
+            present_before_ids=[],
+            returned_ids=["mem-b"],
+        )
+
+        sync_mod.sync(test_logger)
+
+        # Cursor must not have advanced.
+        assert not cursor_file.exists() or (
+            json.loads(cursor_file.read_text()).get("postgres_sync_line", 0) == 0
+        )
+        # Quarantine file must contain the dropped record.
+        assert quarantine.exists()
+        lines = [
+            json.loads(line) for line in quarantine.read_text().splitlines()
+            if line.strip()
+        ]
+        assert len(lines) == 1
+        assert lines[0]["id"] == "mem-a"
+
+    def test_unexpected_drop_result_shape(
+        self, monkeypatch: pytest.MonkeyPatch, test_logger: logging.Logger
+    ) -> None:
+        """Direct check: unexpected_drops is populated on id fall-through."""
+        ids = ["ok-1", "dropped-2", "ok-3"]
+        _install_fake_psycopg2(
+            monkeypatch,
+            present_before_ids=[],
+            returned_ids=["ok-1", "ok-3"],
+        )
+        result = sync_mod.insert_memories(self._make_records(ids), test_logger)
+        assert result.db_available is True
+        assert result.unexpected_drops == ["dropped-2"]
+        assert result.inserted == 2
+
+    def test_db_unavailable_no_advance(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        test_logger: logging.Logger,
+    ) -> None:
+        """psycopg2.connect raising → db_available=False, cursor untouched."""
+        memories = tmp_path / "memories.jsonl"
+        memories.write_text(
+            json.dumps({
+                "id": "mem-a",
+                "category": "progress",
+                "content": "x",
+                "created_at": "2026-04-23T00:00:00Z",
+            }) + "\n",
+            encoding="utf-8",
+        )
+        cursor_file = tmp_path / "sync-cursors.json"
+
+        monkeypatch.setattr(sync_mod, "MEMORIES_FILE", memories)
+        monkeypatch.setattr(sync_mod, "CURSOR_FILE", cursor_file)
+        monkeypatch.setattr(sync_mod, "HAS_EMBED", False)
+
+        _install_fake_psycopg2(
+            monkeypatch,
+            present_before_ids=[],
+            returned_ids=[],
+            raise_on_connect=True,
+        )
+
+        sync_mod.sync(test_logger)
+
+        # Cursor key should not be set.
+        if cursor_file.exists():
+            data = json.loads(cursor_file.read_text())
+            assert "postgres_sync_line" not in data or data["postgres_sync_line"] == 0

--- a/tests/test_sync_sessions.py
+++ b/tests/test_sync_sessions.py
@@ -7,7 +7,11 @@ Tests pure functions only; does not require a running PostgreSQL instance.
 
 import importlib.util
 import json
+import logging
+import sys
+import types
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -376,3 +380,175 @@ class TestEndToEnd:
         assert len(new_sessions) == 1
         _, metadata = new_sessions[0]
         assert metadata["session"]["id"] == "def67890-1234-0000-aaaa-bbbbccccdddd"
+
+
+# ============================================================================
+# Upsert Accounting (#55 fix)
+# ============================================================================
+
+
+class _FakePsycopg2Error(Exception):
+    """Stand-in for ``psycopg2.Error`` in patched-sys.modules tests."""
+
+
+def _install_fake_psycopg2(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    returned_ids: list[str],
+    raise_on_connect: bool = False,
+) -> MagicMock:
+    """
+    Install a fake ``psycopg2`` package into ``sys.modules`` so the
+    function-level import inside ``upsert_sessions`` uses it.
+
+    ``returned_ids`` controls what ``execute_values(fetch=True)`` yields
+    (simulating the ``RETURNING id`` clause).
+    """
+    fake_psycopg2 = types.ModuleType("psycopg2")
+    fake_extras = types.ModuleType("psycopg2.extras")
+
+    # upsert_sessions catches a bare Exception on connect; still define
+    # an Error type for completeness.
+    fake_psycopg2.Error = _FakePsycopg2Error
+
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+
+    if raise_on_connect:
+        fake_psycopg2.connect = MagicMock(
+            side_effect=_FakePsycopg2Error("DB down")
+        )
+    else:
+        fake_psycopg2.connect = MagicMock(return_value=conn)
+
+    fake_extras.execute_values = MagicMock(
+        return_value=[(mid,) for mid in returned_ids]
+    )
+
+    monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+    monkeypatch.setitem(sys.modules, "psycopg2.extras", fake_extras)
+
+    return conn
+
+
+@pytest.fixture
+def test_logger() -> logging.Logger:
+    """Quiet logger for accountability tests."""
+    return logging.getLogger("test-sync-sessions")
+
+
+def _minimal_row(sid: str) -> dict:
+    """Build a minimal session row dict populated for every column."""
+    columns = [
+        "id", "project", "project_directory", "title", "purpose", "tags",
+        "started_at", "ended_at", "duration_minutes",
+        "model_provider", "model_id",
+        "turns", "human_messages", "assistant_messages",
+        "thinking_blocks", "tool_calls",
+        "tokens_input", "tokens_output",
+        "tokens_cache_read", "tokens_cache_creation",
+        "estimated_cost_usd",
+        "prompt_summary", "process_summary", "provenance_summary",
+        "archive_path", "capture_type",
+        "subagent_count", "subagent_total_cost_usd",
+        "raw_metadata",
+    ]
+    row = {c: None for c in columns}
+    row["id"] = sid
+    row["project"] = "test"
+    row["tags"] = []
+    row["subagent_count"] = 0
+    row["subagent_total_cost_usd"] = 0.0
+    row["raw_metadata"] = "{}"
+    return row
+
+
+class TestUpsertSessionsAccounting:
+    """Row-level accounting for :func:`upsert_sessions` (#55)."""
+
+    def test_all_rows_returned(
+        self, monkeypatch: pytest.MonkeyPatch, test_logger: logging.Logger
+    ) -> None:
+        """All input ids returned by DO UPDATE → no drops, full insert."""
+        ids = ["s1", "s2", "s3"]
+        _install_fake_psycopg2(monkeypatch, returned_ids=ids)
+        rows = [_minimal_row(sid) for sid in ids]
+        result = sync_mod.upsert_sessions(rows, test_logger)
+        assert result.db_available is True
+        assert result.input_count == 3
+        assert result.inserted == 3
+        assert result.unexpected_drops == []
+
+    def test_unexpected_drop_recorded(
+        self, monkeypatch: pytest.MonkeyPatch, test_logger: logging.Logger
+    ) -> None:
+        """Id absent from RETURNING → unexpected_drops populated."""
+        ids = ["s1", "s2", "s3"]
+        _install_fake_psycopg2(monkeypatch, returned_ids=["s1", "s3"])
+        rows = [_minimal_row(sid) for sid in ids]
+        result = sync_mod.upsert_sessions(rows, test_logger)
+        assert result.db_available is True
+        assert result.inserted == 2
+        assert result.unexpected_drops == ["s2"]
+
+    def test_drop_halts_cursor_and_quarantines(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        archive_tree: Path,
+        test_logger: logging.Logger,
+    ) -> None:
+        """Unexpected drop → cursor not advanced, row written to quarantine."""
+        cursor_file = tmp_path / "sync-cursors.json"
+        quarantine = tmp_path / "sessions-quarantine.jsonl"
+        monkeypatch.setattr(sync_mod, "CURSOR_FILE", cursor_file)
+        monkeypatch.setattr(sync_mod, "QUARANTINE_FILE", quarantine)
+
+        # Both sessions in archive_tree will be discovered. Return only one
+        # id so the other is "dropped".
+        _install_fake_psycopg2(
+            monkeypatch,
+            returned_ids=["abc12345-6789-0000-aaaa-bbbbccccdddd"],
+        )
+
+        sync_mod.sync(archive_tree, full_resync=True, logger=test_logger)
+
+        # Cursor must not have advanced — no sessions_sync_timestamp key.
+        if cursor_file.exists():
+            data = json.loads(cursor_file.read_text())
+            assert "sessions_sync_timestamp" not in data
+        # Quarantine file should contain the dropped session row.
+        assert quarantine.exists()
+        lines = [
+            json.loads(line) for line in quarantine.read_text().splitlines()
+            if line.strip()
+        ]
+        assert len(lines) == 1
+        assert lines[0]["id"] == "def67890-1234-0000-aaaa-bbbbccccdddd"
+
+    def test_db_unavailable_no_advance(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        archive_tree: Path,
+        test_logger: logging.Logger,
+    ) -> None:
+        """connect raising → db_available=False, cursor untouched."""
+        cursor_file = tmp_path / "sync-cursors.json"
+        monkeypatch.setattr(sync_mod, "CURSOR_FILE", cursor_file)
+
+        _install_fake_psycopg2(
+            monkeypatch, returned_ids=[], raise_on_connect=True
+        )
+
+        sync_mod.sync(archive_tree, full_resync=True, logger=test_logger)
+
+        if cursor_file.exists():
+            data = json.loads(cursor_file.read_text())
+            assert "sessions_sync_timestamp" not in data

--- a/tests/test_sync_sessions.py
+++ b/tests/test_sync_sessions.py
@@ -391,29 +391,41 @@ class _FakePsycopg2Error(Exception):
     """Stand-in for ``psycopg2.Error`` in patched-sys.modules tests."""
 
 
+class _FakePsycopg2OperationalError(_FakePsycopg2Error):
+    """Stand-in for ``psycopg2.OperationalError`` (subclass of Error)."""
+
+
 def _install_fake_psycopg2(
     monkeypatch: pytest.MonkeyPatch,
     *,
     returned_ids: list[str],
     raise_on_connect: bool = False,
+    advisory_lock_acquired: bool = True,
 ) -> MagicMock:
     """
     Install a fake ``psycopg2`` package into ``sys.modules`` so the
-    function-level import inside ``upsert_sessions`` uses it.
+    function-level import inside ``upsert_sessions`` and the advisory-
+    lock helper use it.
 
     ``returned_ids`` controls what ``execute_values(fetch=True)`` yields
-    (simulating the ``RETURNING id`` clause).
+    (simulating the ``RETURNING id`` clause). ``advisory_lock_acquired``
+    controls what ``pg_try_advisory_lock`` reports back (for tests that
+    want to exercise the contended-lock path).
     """
     fake_psycopg2 = types.ModuleType("psycopg2")
     fake_extras = types.ModuleType("psycopg2.extras")
 
-    # upsert_sessions catches a bare Exception on connect; still define
-    # an Error type for completeness.
     fake_psycopg2.Error = _FakePsycopg2Error
+    fake_psycopg2.OperationalError = _FakePsycopg2OperationalError
 
     cur = MagicMock()
     cur.__enter__ = MagicMock(return_value=cur)
     cur.__exit__ = MagicMock(return_value=False)
+    # pg_try_advisory_lock(...) → [(True,)] or [(False,)] depending on
+    # flag. The upsert path's SELECT does not fetchone; the advisory
+    # lock path does. Returning a tuple is harmless for paths that
+    # ignore fetchone.
+    cur.fetchone.return_value = (advisory_lock_acquired,)
 
     conn = MagicMock()
     conn.cursor.return_value = cur
@@ -422,7 +434,7 @@ def _install_fake_psycopg2(
 
     if raise_on_connect:
         fake_psycopg2.connect = MagicMock(
-            side_effect=_FakePsycopg2Error("DB down")
+            side_effect=_FakePsycopg2OperationalError("DB down")
         )
     else:
         fake_psycopg2.connect = MagicMock(return_value=conn)
@@ -552,3 +564,94 @@ class TestUpsertSessionsAccounting:
         if cursor_file.exists():
             data = json.loads(cursor_file.read_text())
             assert "sessions_sync_timestamp" not in data
+
+    def test_within_batch_dedup_last_wins(
+        self, monkeypatch: pytest.MonkeyPatch, test_logger: logging.Logger
+    ) -> None:
+        """Duplicate session ids in one batch collapse to the last row."""
+        rows = [
+            _minimal_row("s-dup"),
+            _minimal_row("s-new"),
+            _minimal_row("s-dup"),
+        ]
+        # Mark the two dup rows so we can see which one "won".
+        rows[0]["title"] = "first"
+        rows[2]["title"] = "second"
+
+        _install_fake_psycopg2(
+            monkeypatch, returned_ids=["s-dup", "s-new"]
+        )
+        result = sync_mod.upsert_sessions(rows, test_logger)
+        assert result.db_available is True
+        assert result.duplicates_within_batch == 1
+        assert result.input_count == 2  # deduped
+        assert result.inserted == 2
+        assert result.unexpected_drops == []
+
+    def test_quarantine_dedup_skips_already_present(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+        test_logger: logging.Logger,
+    ) -> None:
+        """Repeated quarantine calls for the same id append only once."""
+        quarantine = tmp_path / "sessions-quarantine.jsonl"
+        monkeypatch.setattr(sync_mod, "QUARANTINE_FILE", quarantine)
+
+        dropped = [{"id": "s-x", "title": "t"}]
+        sync_mod._write_quarantine(dropped, test_logger)
+        sync_mod._write_quarantine(dropped, test_logger)
+
+        lines = [
+            json.loads(line) for line in quarantine.read_text().splitlines()
+            if line.strip()
+        ]
+        assert len(lines) == 1
+        assert lines[0]["id"] == "s-x"
+
+    def test_advisory_lock_contended_skips_sync(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        archive_tree: Path,
+        test_logger: logging.Logger,
+    ) -> None:
+        """Contended advisory lock → sync exits without calling upsert."""
+        cursor_file = tmp_path / "sync-cursors.json"
+        monkeypatch.setattr(sync_mod, "CURSOR_FILE", cursor_file)
+
+        _install_fake_psycopg2(
+            monkeypatch,
+            returned_ids=["abc12345-6789-0000-aaaa-bbbbccccdddd"],
+            advisory_lock_acquired=False,
+        )
+
+        called = {"upsert": False}
+        orig_upsert = sync_mod.upsert_sessions
+
+        def _spy(rows, logger):
+            called["upsert"] = True
+            return orig_upsert(rows, logger)
+
+        monkeypatch.setattr(sync_mod, "upsert_sessions", _spy)
+
+        sync_mod.sync(archive_tree, full_resync=True, logger=test_logger)
+
+        assert called["upsert"] is False
+        if cursor_file.exists():
+            data = json.loads(cursor_file.read_text())
+            assert "sessions_sync_timestamp" not in data
+
+    def test_narrow_exception_reraises_non_psycopg_errors(
+        self, monkeypatch: pytest.MonkeyPatch, test_logger: logging.Logger
+    ) -> None:
+        """
+        KeyError from a malformed row bubbles up rather than being
+        reported as db_available=False — programmer bugs should not be
+        disguised as transient DB trouble.
+        """
+        _install_fake_psycopg2(monkeypatch, returned_ids=[])
+        sys.modules["psycopg2.extras"].execute_values = MagicMock(
+            side_effect=KeyError("missing column")
+        )
+        rows = [_minimal_row("s-a")]
+        with pytest.raises(KeyError):
+            sync_mod.upsert_sessions(rows, test_logger)


### PR DESCRIPTION
## Summary

Fixes #55 — silent row loss in `sync-to-postgres.py` and `sync-sessions-to-postgres.py`.

**Root cause:** `insert_memories()` / `upsert_sessions()` returned `len(records)` (input count) rather than the actual rows inserted by `execute_values(... ON CONFLICT ...)`. The cursor advanced on this dishonest count, silently passing over rows dropped by ON CONFLICT. 702 of ~19,230 memory rows were lost this way before `rebuild-postgres.py` recovered them.

**Fix shape:**

- **Pre-flight SELECT** partitions each input batch into three buckets: `expected_dupe` (already in DB), `inserted` (returned by `RETURNING id`), `UNEXPECTED_DROP` (in neither). Only the third bucket alarms — legitimate re-sync/dedupe hits stay quiet.
- **`RETURNING id` + `execute_values(..., fetch=True)`** gives a true per-row insertion count.
- **Hard-stop cursor advance** on any unexpected drop. Dropped records (full input dicts, not just ids) are appended to a quarantine JSONL for replay: `data/memories/quarantine-postgres-drops.jsonl`, `data/sessions/quarantine-postgres-drops.jsonl`.
- **Sessions variant** uses DO UPDATE, so every input id must appear in `RETURNING` — no pre-flight needed; any missing id is anomalous.

## Sequencing (audit-first rollout)

Landed as two commits so the detection half can run standalone before the behavioural fix is deployed:

1. **`8b6b506` — feat(scripts): add audit-postgres-sync for detecting silent row loss**
   Read-only reconciliation (`ids_in_jsonl` vs `ids_in_pg`, `--sessions` flag for archive vs sessions table). Exit 1 on `only_in_canonical`. Run before deploying the behavioural fix to confirm no latent gaps.

2. **`f31858c` — fix(sync): halt cursor on unexpected ON CONFLICT drops (#55)**
   `InsertResult` NamedTuple with `(input_count, inserted, expected_dupes, unexpected_drops, db_available)`. Cursor gating replaces `if inserted > 0` with policy: advance only when `unexpected_drops` empty AND `db_available`. On drops, write to quarantine + log ERROR + return without `save_cursor()`.

## Pre-merge verification

Audit ran clean against live PG (2026-04-23):

```
=== memories audit ===
  canonical count :    19396
  postgres count  :    19396
  only in canonical:       0     ← the bug's fingerprint
  only in postgres :       0

=== sessions audit ===
  canonical count :     352
  postgres count  :     353
  only in canonical:       0     ← clean
  only in postgres :       1     ← orphan from deletion (separate concern)
```

Zero canonical rows missing from PG on either track, so the cursor-halt will NOT alarm on first live run post-merge.

## Test plan

- [x] `TestInsertMemoriesAccounting` — all-new, all-dupes, mixed, unexpected-drop-halts-cursor, db-unavailable-no-advance, result-shape (6 cases).
- [x] `TestUpsertSessionsAccounting` — mirrored 4 cases (no pre-flight branch).
- [x] Audit smoke tests (8 cases).
- [x] All 66 tests pass in the three affected test files.
- [x] `audit-postgres-sync.py` run against live PG shows clean state pre-deploy.
- [ ] Post-merge: re-run audit after first cron sync to confirm fix holds on new data.
- [ ] Follow-up (separate): clean up session orphan `f3cec15d` in PG.

## Files

- `scripts/sync-to-postgres.py` (modify: +216 / -35)
- `scripts/sync-sessions-to-postgres.py` (modify: +165 / -20)
- `scripts/audit-postgres-sync.py` (new, +328)
- `tests/test_sync_script.py` (+244)
- `tests/test_sync_sessions.py` (new, +176)
- `tests/test_audit_postgres_sync.py` (new, +144)

Closes #55.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)