### PR TITLE
fix(lit-scout): title registry-first + broaden verifier authors check

### DIFF
--- a/agents/lit-scout-verifier.md
+++ b/agents/lit-scout-verifier.md
@@ -80,20 +80,40 @@ For every row in the findings table:
 ```
 
 Parse the JSON response. Extract:
-- `authors` array — first element's family name
+- `authors` array — the full ordered list of family names, plus the
+  total author count (not only the first element)
 - `year`
 - `title`
 - `citation_count`
 
 Compare against the row's claims. A claim **passes** if:
 - Authors: the row's attribution (e.g., "Walters et al." or
-  "Walters & Wilder") has first author's family name matching the
-  API's `authors[0]`. Small formatting differences are OK; wrong
-  family names are NOT. Note that CrossRef's `family`/`given`
-  encoding can be wrong — apply domain judgement where the encoding
-  is visibly swapped (e.g., if CrossRef returns `family="Philippe"`
-  for a paper whose author is widely known as "Philippe Lanos", the
-  true family name is Lanos, not Philippe).
+  "Walters & Wilder") must agree with the API on **all** of the
+  following, not just the first author:
+  1. **First-author family name** — matches the API's `authors[0]`
+     family name. Small formatting differences are OK; a wrong family
+     name is NOT.
+  2. **Author count** — the number of authors the attribution implies
+     matches the API's author-list length. "Smith & Jones" implies
+     exactly two; "Smith et al." implies three or more; a bare
+     "Smith" implies one. A count mismatch (e.g., the row names two
+     specific authors but the paper has three) is a real divergence,
+     not a formatting nicety.
+  3. **Every named non-first author** — where the attribution spells
+     out a second (or later) author by family name, each named family
+     name must match the API's author list **in order**. A row that
+     reads "Orengo & Petrie" when the registry's `authors[1]` family
+     is "Garcia-Molsosa" is wrong even though the first author is
+     right. Where the attribution uses "et al." after the first
+     author, only the count band (≥3) is checked, not the specific
+     later names, since "et al." does not assert them.
+
+  Apply domain judgement to CrossRef's `family`/`given` encoding,
+  which can be swapped at the source — e.g., if CrossRef returns
+  `family="Philippe"` for a paper whose author is widely known as
+  "Philippe Lanos", the true family name is Lanos, not Philippe.
+  This judgement applies to every position you compare, not only the
+  first author.
 - Year: matches exactly.
 - Title: matches approximately (minor formatting/capitalisation OK).
 - Cites: within 10% of API value, OR both within 20 of each other
@@ -114,11 +134,44 @@ PASS and FAIL and is defined per field as follows:
 
 | Field | PASS | PARTIAL | FAIL |
 |---|---|---|---|
-| `authors` | First author family name matches; minor formatting variation OK | Wrong rendering style ("Smith & Jones" vs "Smith and Jones") but same first author family name | Wrong first author family name |
+| `authors` | First-author family matches, author count matches, and every named non-first author family matches in order; minor formatting variation OK | Wrong rendering style only ("Smith & Jones" vs "Smith and Jones") with first author, count, and all named authors otherwise correct | Wrong first-author family, **OR** author count mismatch, **OR** any named non-first author family wrong/misordered |
 | `year` | Exact match | ±1 year (covers publication-date vs first-online-date ambiguity that CrossRef sometimes surfaces) | Beyond ±1 year |
 | `title` | Approximate match (capitalisation, punctuation, "the" prefix variation OK) | Same paper but markedly different wording (e.g., subtitle present in one, absent in other) | Different paper |
 | `citation_count` | Within 10 % or ±20 absolute (whichever is larger) | Within 25 % or ±50 absolute, but exceeds PASS | Beyond — different paper, stale fetch, or count from a different API |
 | `doi_resolves` | DOI resolves to the expected paper | (no PARTIAL — binary check) | DOI does not resolve, or resolves to a different paper |
+
+**Why count and non-first-author mismatches must be FAIL, not
+PARTIAL.** The driver iterates on FAIL only; a PARTIAL verdict surfaces
+to the user as a footnote and does **not** propagate a corrected value
+back into `claims.jsonl`, so the Zotero importer would still receive
+the wrong attribution. The `authors` PARTIAL band is therefore reserved
+strictly for cosmetic rendering differences (separator/`et al.` style)
+where the underlying first author, count, and every named author are
+all correct. Any substantive author divergence — wrong first author,
+wrong count, or a wrong/misordered later author — is a FAIL so that
+iterate-mode is triggered and a corrected `true_value` is propagated.
+When you emit the FAIL claim, put the **full corrected attribution** in
+`true_value` (first author plus the corrected later authors / count, in
+the row's rendering style), not just the first author, so the proposer
+substitutes the whole correct list.
+
+**Worked example — the Orengo/Petrie → Garcia-Molsosa case
+(2026-06-25 run).** The proposer rendered a row as
+"Orengo, H.A.; Petrie, C.A. (2022)". The first-author family (Orengo)
+is correct, so the old first-author-only rubric scored the row PASS and
+never triggered an iteration. But the registry's `authors` list is
+`[Orengo, Garcia-Molsosa, …]` — the real second author is
+Garcia-Molsosa; "Petrie" was cross-contaminated from an adjacent
+same-first-author row. Under the broadened rubric this is a FAIL on
+`authors`: the first author matches but the named second-author family
+("Petrie") does not match the registry's `authors[1]` ("Garcia-Molsosa").
+The FAIL claim carries `true_value` of the corrected attribution
+(e.g., "Orengo, Garcia-Molsosa et al. (2022)") and a `fix_hint` naming
+the substitution, so iterate-mode corrects the row rather than letting
+the wrong second author pass silently. Had the row instead read
+"Orengo et al. (2022)" with the registry showing three or more authors,
+that "et al." asserts only the ≥3 count (which matches) and no specific
+second name, so it would PASS on the count band.
 
 **Severity (FAIL claims only)** — a separate axis from tolerance.
 Tolerance decides PASS/PARTIAL/FAIL; severity ranks FAIL claims for

--- a/scripts/lit-scout-zotero-import.py
+++ b/scripts/lit-scout-zotero-import.py
@@ -1049,7 +1049,11 @@ def build_zotero_item(
     Build a Zotero item dict suitable for `zot.create_items([item])`.
 
     Authoritative source for each field:
-      - title, year, citation_count, doi_resolves: from claims (corrected)
+      - title: from the registry record's `title` (CrossRef/DataCite/
+        OpenAlex), which carries the full, untruncated title; the claims
+        `title` string is only a fallback when the record has none (see
+        the title block below for why — symmetric with authors)
+      - year, citation_count, doi_resolves: from claims (corrected)
       - authors: from the registry record's structured `author` field
         (CrossRef/DataCite/OpenAlex), which carries the full, correctly
         ordered list; the claims `authors` string is only a fallback when
@@ -1067,17 +1071,38 @@ def build_zotero_item(
         EXTRA_TYPE_TO_ZOTERO_TYPE.get(cr_type, "journalArticle")
     )
 
-    # Title: prefer the claims value (corrected, even if it is the
-    # empty string) over CrossRef; only fall back to CrossRef when the
-    # claims-side value is absent or None. Direct `or` would skip a
-    # legitimately empty correction and silently restore the CrossRef
-    # title, drifting away from the verifier's output.
+    # Title: registry-first, symmetric with the authors block below. The
+    # registry record's `title` (CrossRef for journals/books, DataCite for
+    # arXiv/Zenodo, OpenAlex as the backstop) carries the full, untruncated
+    # title; the claims-contract `title` is the lit-scout proposer's
+    # rendering, which has been observed to truncate or reword the title.
+    # The verifier scores a title mismatch as PARTIAL (not FAIL), and
+    # iterate-mode only propagates FAIL corrections back into claims.jsonl,
+    # so a truncated proposer title is never corrected upstream and lands in
+    # Zotero verbatim unless we prefer the registry here. In the 2026-06-25
+    # run, 8 of 24 titles were truncated and only a manual patch avoided
+    # corruption. Preferring the registry cannot discard a verifier
+    # correction the same way the authors block cannot: the registry record
+    # is exactly the authority the verifier checks titles against.
+    #
+    # Priority:
+    #   1. Registry record has a non-empty `title` → that is canonical.
+    #   2. Else fall back to the claims `title` value. An explicit empty
+    #      correction (the claims `value` is the empty string) is preserved
+    #      rather than coerced away, mirroring the old behaviour's care with
+    #      empty corrections; only an absent/None claim yields "".
+    # Note the asymmetry in the empty-string handling between the two
+    # sources: an empty *registry* title must NOT clobber a usable claims
+    # title (hence the truthiness test on `registry_title`), whereas an
+    # empty *claims* title is a legitimate (if rare) correction and is kept.
+    registry_title = (crossref_msg.get("title") or [""])[0]
     title_claim = (claims_for_doi.get("title") or {}).get("value")
-    title = (
-        title_claim
-        if title_claim is not None
-        else (crossref_msg.get("title") or [""])[0]
-    )
+    if registry_title:
+        title = registry_title
+    elif title_claim is not None:
+        title = title_claim
+    else:
+        title = ""
 
     # Year/date: claims has integer year; CrossRef date is richer.
     year = (claims_for_doi.get("year") or {}).get("value")
@@ -1103,11 +1128,13 @@ def build_zotero_item(
     # Round-tripping that string through `parse_author_string` produced the
     # corruption seen in staged records: year-as-surname (the "(1978/1980)" tail
     # has a slash, so the year-strip regex misses it and the token becomes the
-    # family name), flattened order, and blank given names. The verifier never
-    # catches this --- it validates only the first-author FAMILY against CrossRef,
-    # not the creator field this importer writes --- so the damage is downstream
-    # of verification. The registry record is exactly the authority the verifier
-    # checks against, so preferring it cannot discard a verifier correction; it
+    # family name), flattened order, and blank given names. The verifier checks
+    # the proposer's attribution STRING (first author, count, and named later
+    # authors --- broadened 2026-06-26), not the structured creator field this
+    # importer writes, so even a clean verification does not guarantee a clean
+    # round-trip of the claims string. The registry record is exactly the
+    # authority the verifier checks against, so preferring it cannot discard a
+    # verifier correction; it
     # restores the full list the short claim string only gestured at.
     #
     # Priority, therefore:

--- a/tests/test_lit_scout_zotero_import.py
+++ b/tests/test_lit_scout_zotero_import.py
@@ -1,0 +1,215 @@
+"""Behavioural tests for the lit-scout Zotero importer's field sourcing.
+
+These tests pin the "authoritative source" contract for two fields that
+``build_zotero_item`` writes into a staged Zotero item:
+
+  * **Title** — registry-first (FIX 1(a), 2026-06-26). The registry
+    record's ``title`` carries the full, untruncated title; the proposer's
+    claims ``title`` is only a fallback when the registry has none. This
+    prevents a proposer-truncated title (scored merely PARTIAL by the
+    verifier, and therefore never corrected back into ``claims.jsonl``)
+    from silently landing in Zotero. In the 2026-06-25 run, 8 of 24 titles
+    were truncated and only a manual patch avoided corruption.
+  * **Authors** — registry-first (the pre-existing contract; covered here
+    as a regression guard so the FIX 1(a) title change did not perturb it).
+
+The registry record (a CrossRef-``message``-style dict) and the claims
+dict are stubbed inline; no network calls are made.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the importer module by path. It lives under ``scripts/`` with a
+# hyphenated filename (not an importable package name), so we load it via
+# an explicit spec rather than a plain ``import``.
+# ---------------------------------------------------------------------------
+_IMPORTER_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "lit-scout-zotero-import.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "lit_scout_zotero_import", _IMPORTER_PATH
+)
+assert _spec is not None and _spec.loader is not None
+_importer = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_importer)
+
+build_zotero_item = _importer.build_zotero_item
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _claims(
+    *,
+    title: Any = "claims title",
+    include_title: bool = True,
+    authors: Any = "Proposer, A. (2022)",
+    include_authors: bool = True,
+) -> dict[str, dict]:
+    """Build a minimal ``claims_for_doi`` mapping.
+
+    Each claim category maps to a dict carrying a ``value`` key, matching the
+    shape ``group_claims_by_doi`` produces. ``include_*`` toggles let a test
+    omit a category entirely (distinct from supplying ``value=None``).
+    """
+    claims: dict[str, dict] = {"year": {"value": 2022}}
+    if include_title:
+        claims["title"] = {"value": title}
+    if include_authors:
+        claims["authors"] = {"value": authors}
+    return claims
+
+
+def _crossref(
+    *,
+    title: Any = "Registry Title",
+    author: list[dict] | None = None,
+) -> dict:
+    """Build a minimal CrossRef-``message``-style registry record.
+
+    ``title`` is wrapped in a list to match CrossRef's array shape; pass an
+    empty list or ``None`` to model a record with no title.
+    """
+    msg: dict[str, Any] = {"type": "journal-article"}
+    if title is None:
+        # Model "key present but empty list" — the importer's
+        # ``(crossref_msg.get("title") or [""])[0]`` should yield "".
+        msg["title"] = []
+    else:
+        msg["title"] = [title]
+    if author is not None:
+        msg["author"] = author
+    return msg
+
+
+def _build(claims: dict[str, dict], crossref: dict) -> dict:
+    """Invoke ``build_zotero_item`` with inert defaults for the rest."""
+    return build_zotero_item(
+        doi="10.1000/test",
+        claims_for_doi=claims,
+        crossref_msg=crossref,
+        table_row={},
+        corrections_for_doi={},
+        run_timestamp="20260626-000000",
+        subcollection_key="ABCD1234",
+    )
+
+
+# ---------------------------------------------------------------------------
+# FIX 1(a): title is registry-first
+# ---------------------------------------------------------------------------
+def test_registry_title_wins_over_truncated_claims_title() -> None:
+    """A present registry title overrides a truncated claims title."""
+    claims = _claims(title="A truncated proposer titl")  # noqa: deliberate
+    crossref = _crossref(
+        title="A Truncated Proposer Title That Goes The Full Distance"
+    )
+    item = _build(claims, crossref)
+    assert item["title"] == (
+        "A Truncated Proposer Title That Goes The Full Distance"
+    )
+
+
+def test_claims_title_used_when_registry_title_empty_list() -> None:
+    """An empty registry title list falls back to the claims title."""
+    claims = _claims(title="Sole Surviving Claims Title")
+    crossref = _crossref(title=None)  # -> "title": []
+    item = _build(claims, crossref)
+    assert item["title"] == "Sole Surviving Claims Title"
+
+
+def test_claims_title_used_when_registry_title_absent() -> None:
+    """A registry record with no ``title`` key falls back to the claim."""
+    claims = _claims(title="Fallback Claims Title")
+    crossref = {"type": "journal-article"}  # no "title" key at all
+    item = _build(claims, crossref)
+    assert item["title"] == "Fallback Claims Title"
+
+
+def test_empty_registry_title_does_not_clobber_usable_claims_title() -> None:
+    """An empty-string registry title must not win over a usable claim.
+
+    Models a registry record whose title array contains a single empty
+    string (rather than being absent), which is falsy and so must defer to
+    the claims title rather than writing a blank title into Zotero.
+    """
+    claims = _claims(title="Real Title From Claims")
+    crossref = _crossref(title="")  # -> "title": [""]
+    item = _build(claims, crossref)
+    assert item["title"] == "Real Title From Claims"
+
+
+def test_absent_claims_title_yields_empty_when_registry_also_empty() -> None:
+    """No registry title and no claims title key → empty title, not error."""
+    claims = _claims(include_title=False)
+    crossref = _crossref(title=None)  # -> "title": []
+    item = _build(claims, crossref)
+    assert item["title"] == ""
+
+
+def test_empty_claims_correction_preserved_when_registry_empty() -> None:
+    """An explicit empty claims correction is preserved over a blank registry.
+
+    Mirrors the importer's documented care with empty corrections: when the
+    registry title is empty and the claims ``value`` is the empty string
+    (a deliberate correction, not an absent value), the empty string is
+    kept rather than coerced to anything else.
+    """
+    claims = _claims(title="")  # explicit empty correction
+    crossref = _crossref(title=None)  # -> "title": []
+    item = _build(claims, crossref)
+    assert item["title"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Regression: authors remain registry-first
+# ---------------------------------------------------------------------------
+def test_authors_remain_registry_first() -> None:
+    """The structured registry author list wins over the claims string.
+
+    Guards the pre-existing authors contract against regression from the
+    FIX 1(a) title change: the registry's ordered ``author`` list must be
+    written as creators, not the proposer's short display rendering.
+    """
+    claims = _claims(authors="Wrongname, X. (2022)")
+    crossref = _crossref(
+        author=[
+            {"family": "Orengo", "given": "H. A."},
+            {"family": "Garcia-Molsosa", "given": "A."},
+        ],
+    )
+    item = _build(claims, crossref)
+    creators = item["creators"]
+    assert [c["lastName"] for c in creators] == ["Orengo", "Garcia-Molsosa"]
+    assert all(c["creatorType"] == "author" for c in creators)
+
+
+def test_authors_fall_back_to_claims_when_registry_has_none() -> None:
+    """With no registry author list, the claims string is parsed instead.
+
+    Uses the canonical semicolon-delimited "Family, Given" form, which is
+    the shape ``parse_author_string`` maps onto ``lastName``/``firstName``
+    creators. (The proposer's comma-only display form is intentionally
+    lossy on this fallback path — see ``parse_author_string`` — so the
+    point being guarded here is simply that the fallback fires at all.)
+    """
+    claims = _claims(authors="Solo, Sam; Doe, Jane")
+    crossref = _crossref(author=None)  # no "author" key
+    item = _build(claims, crossref)
+    creators = item["creators"]
+    assert creators, "expected the claims string to yield at least one creator"
+    assert creators[0]["lastName"] == "Solo"
+    assert creators[0]["firstName"] == "Sam"
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Two fixes to the lit-scout verification/import pipeline, both motivated by failures observed in the real run on 2026-06-25.

### FIX 1(a) — imported title is now registry-first (symmetric with authors)

`build_zotero_item` in `scripts/lit-scout-zotero-import.py` sourced the Zotero **title** claims-first, only falling back to CrossRef. Because the verifier scores a title mismatch as `PARTIAL` (not `FAIL`) and iterate-mode propagates **only** `FAIL` corrections back into `claims.jsonl`, a proposer-truncated or reworded title is never corrected upstream and lands in the staged record verbatim. In the 2026-06-25 run, **8 of 24 titles were truncated** and only a manual patch avoided corruption.

The title is now sourced **registry-first**: prefer the CrossRef/DataCite/OpenAlex `title` when present and non-empty, fall back to the claims `title` otherwise — mirroring the existing registry-first authors block directly below it. The empty-string handling is deliberately asymmetric and documented inline: an empty *registry* title must not clobber a usable *claims* title, whereas an explicit empty *claims* correction is preserved rather than coerced away.

### FIX 2 — verifier authors check broadened beyond first-author family

`agents/lit-scout-verifier.md` keyed the authors check **only** on the first-author family name, so a wrong *second* author scored `PASS` and never triggered an iteration. In the 2026-06-25 run the proposer rendered a paper as "Orengo, H.A.; Petrie, C.A." when the real second author is **Garcia-Molsosa** (Petrie was cross-contaminated from an adjacent same-first-author row); the rubric could not see it.

The authors rubric now also compares:
1. the **author count** (claimed vs registry), and
2. **every named non-first author family**, in order.

A count mismatch, or any wrong/misordered named non-first author, escalates to **`FAIL`** (which propagates a corrected `true_value` via iterate-mode), not a silent non-propagating `PARTIAL`. The `PARTIAL` band is now reserved strictly for cosmetic rendering differences. `et al.` after the first author asserts only the count band (≥3), not specific later names. The first-author-family check is unchanged — this is purely additive. A worked example using the Orengo/Petrie → Garcia-Molsosa case is included in the spec.

## Files changed

- `scripts/lit-scout-zotero-import.py` — title block + docstring made registry-first; stale comment about the verifier "validating only the first-author family" updated to reflect the broadened rubric.
- `agents/lit-scout-verifier.md` — verification-method extraction list, PASS-criteria prose, tolerance table `authors` row, a new "why count/non-first-author mismatches must be FAIL" note, and a worked example.
- `tests/test_lit_scout_zotero_import.py` — **new** (the importer previously had no permanent coverage).

## Test coverage added

8 behavioural tests for `build_zotero_item`, all passing (plus 65 pre-existing zotero-related tests still green):
- registry title present → registry wins over a truncated claims title
- registry title absent (no key) → claims title used
- registry title empty list → claims title used
- empty-string registry title (`[""]`) does not clobber a usable claims title
- no registry title and no claims title key → empty string, no error
- explicit empty claims correction preserved when registry empty
- **regression:** authors remain registry-first (structured list wins over claims string)
- authors fall back to claims string when registry has no author list

FIX 2 is an LLM-agent-spec (markdown) change, so no unit test applies; the spec edit is self-consistent and the intended behaviour is documented above.

## For Shawn to eyeball

- **`~/.claude/agents/lit-scout-verifier.md` is a symlink** to `agents/lit-scout-verifier.md` (verified), so no separate copy needed syncing. No rubric duplication was found in `commands/` (the lit-scout command files reference PARTIAL/FAIL verdicts generically but do not restate the authors rubric).
- The `true_value` for an author FAIL should now carry the **full corrected attribution** (not just the first author) so iterate-mode substitutes the whole list — please confirm this matches your intent for how the proposer consumes corrections.
- No linters (ruff/flake8/markdownlint) are installed in the venv; line-length was checked manually (all new lines ≤100 / prose hard-wrapped ~72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)